### PR TITLE
feat: add drafts management panel for authors

### DIFF
--- a/src/lib/database.rs
+++ b/src/lib/database.rs
@@ -47,6 +47,8 @@ impl DatabaseConnection {
                 description TEXT NOT NULL,
                 body TEXT NOT NULL,
                 author_id TEXT NOT NULL,
+                category_id TEXT,
+                draft INTEGER NOT NULL DEFAULT 0,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at TEXT NOT NULL DEFAULT (datetime('now')),
                 FOREIGN KEY (author_id) REFERENCES users (id) ON DELETE CASCADE

--- a/src/lib/routes/articles.rs
+++ b/src/lib/routes/articles.rs
@@ -2092,3 +2092,225 @@ pub async fn get_api_keys_admin_page(
 
     Ok(Html(html))
 }
+
+/// List draft articles for the authenticated user
+pub async fn list_user_drafts(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+) -> Result<Json<MultipleArticlesResponse>, AppError> {
+    let conn = state
+        .db
+        .connect()
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+    // Query only draft articles for the current user
+    let sql = r#"
+        SELECT
+            a.id, a.slug, a.title, a.description, a.body, a.created_at, a.updated_at,
+            u.username, u.bio, u.image,
+            c.slug as category_slug, a.draft
+        FROM articles a
+        JOIN users u ON a.author_id = u.id
+        LEFT JOIN categories c ON a.category_id = c.id
+        WHERE a.author_id = ? AND a.draft = 1
+        ORDER BY a.updated_at DESC
+        "#;
+
+    let params = libsql::params![user.user_id.to_string()];
+
+    let mut article_rows = conn
+        .query(sql, params)
+        .await
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+    let mut articles = Vec::new();
+
+    while let Some(row) = article_rows
+        .next()
+        .await
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?
+    {
+        let article_id: String = row
+            .get(0)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let slug: String = row
+            .get(1)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let title: String = row
+            .get(2)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let description: String = row
+            .get(3)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let body: String = row
+            .get(4)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let created_at_str: String = row
+            .get(5)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let updated_at_str: String = row
+            .get(6)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let username: String = row
+            .get(7)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let bio: Option<String> = row.get(8).ok();
+        let image: Option<String> = row.get(9).ok();
+        let category_slug: Option<String> = row.get(10).ok();
+        let draft: i64 = row
+            .get(11)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let is_draft = draft_int_to_bool(draft);
+
+        let created_at = chrono::DateTime::parse_from_rfc3339(&created_at_str)
+            .map_err(|e| AppError::InternalServerError(format!("Invalid timestamp: {}", e)))?
+            .with_timezone(&Utc);
+        let updated_at = chrono::DateTime::parse_from_rfc3339(&updated_at_str)
+            .map_err(|e| AppError::InternalServerError(format!("Invalid timestamp: {}", e)))?
+            .with_timezone(&Utc);
+
+        // Get tags for this article
+        let mut tag_rows = conn
+            .query(
+                r#"
+                SELECT t.name
+                FROM tags t
+                JOIN article_tags at ON t.id = at.tag_id
+                WHERE at.article_id = ?
+                "#,
+                libsql::params![article_id.clone()],
+            )
+            .await
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+        let mut tag_names = Vec::new();
+        while let Some(tag_row) = tag_rows
+            .next()
+            .await
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?
+        {
+            let tag_name: String = tag_row
+                .get(0)
+                .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+            tag_names.push(tag_name);
+        }
+
+        // Get favorites count (drafts won't have many, but for consistency)
+        let mut favorites_rows = conn
+            .query(
+                "SELECT COUNT(*) FROM user_favorites WHERE article_id = ?",
+                libsql::params![article_id],
+            )
+            .await
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+        let favorites_count = if let Some(fav_row) = favorites_rows
+            .next()
+            .await
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?
+        {
+            let count: i64 = fav_row
+                .get(0)
+                .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+            count as i32
+        } else {
+            0
+        };
+
+        let author = UserProfile {
+            username,
+            bio,
+            image,
+            following: false,
+        };
+
+        let rendered_body = markdown_to_html(&body);
+
+        let article_response = ArticleResponse {
+            slug,
+            title,
+            description,
+            body,
+            rendered_body: Some(rendered_body),
+            tag_list: tag_names,
+            category: category_slug,
+            draft: is_draft,
+            created_at,
+            updated_at,
+            favorited: false,
+            favorites_count,
+            author,
+        };
+
+        articles.push(article_response);
+    }
+
+    let articles_count = articles.len() as i32;
+
+    Ok(Json(MultipleArticlesResponse {
+        articles,
+        articles_count,
+    }))
+}
+
+/// Admin page for managing draft articles
+pub async fn get_drafts_admin_page(
+    State(state): State<AppState>,
+    user: AuthenticatedUser,
+) -> Result<impl IntoResponse, AppError> {
+    // Get user info for template context
+    let conn = state
+        .db
+        .connect()
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+    let mut user_rows = conn
+        .query(
+            "SELECT username, email, bio, image FROM users WHERE id = ?",
+            libsql::params![user.user_id.to_string()],
+        )
+        .await
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+
+    let user_info = if let Some(row) = user_rows
+        .next()
+        .await
+        .map_err(|e| AppError::InternalServerError(e.to_string()))?
+    {
+        let username: String = row
+            .get(0)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let email: String = row
+            .get(1)
+            .map_err(|e| AppError::InternalServerError(e.to_string()))?;
+        let bio: Option<String> = row.get(2).ok();
+        let image: Option<String> = row.get(3).ok();
+
+        Some(json!({
+            "username": username,
+            "email": email,
+            "bio": bio,
+            "image": image
+        }))
+    } else {
+        None
+    };
+
+    // Get draft articles for this user
+    let drafts_response = list_user_drafts(State(state.clone()), user.clone()).await?;
+    let drafts = drafts_response.0.articles;
+
+    let context: Value = json!({
+        "title": "Draft Articles - CrustyRustacean Dev Blog",
+        "page": "Drafts",
+        "current_year": Utc::now().year(),
+        "user": user_info,
+        "drafts": drafts,
+    });
+
+    let html = state.templates
+        .render("admin/drafts.html", &tera::Context::from_serialize(&context)?)
+        .map_err(|e| AppError::InternalServerError(format!("Template error: {}", e)))?;
+
+    Ok(Html(html))
+}

--- a/src/lib/startup.rs
+++ b/src/lib/startup.rs
@@ -8,13 +8,13 @@ use crate::routes::{
     follow_user, get_about, get_admin_dashboard, get_api_keys_admin_page, get_article,
     get_article_page, get_articles_feed, get_articles_feed_page, get_articles_list_page,
     get_authors_page, get_categories, get_categories_admin_page, get_category, get_comments,
-    get_current_user, get_edit_article_page, get_editor_page, get_index, get_login_page,
-    get_media_library_page, get_media_metadata, get_my_favorites_page, get_privacy, get_profile,
-    get_profile_page, get_register_page, get_robots_txt, get_rss_feed, get_sitemap, get_tags,
-    get_tags_admin_page, get_terms, handle_404_simple, health_check, list_api_keys, list_articles,
-    list_media, list_profiles, login_user, mobile_upload_article, register_user, search_articles,
-    unfavorite_article, unfollow_user, update_article, update_category, update_current_user,
-    update_media_metadata, update_tag, upload_media,
+    get_current_user, get_drafts_admin_page, get_edit_article_page, get_editor_page, get_index,
+    get_login_page, get_media_library_page, get_media_metadata, get_my_favorites_page, get_privacy,
+    get_profile, get_profile_page, get_register_page, get_robots_txt, get_rss_feed, get_sitemap,
+    get_tags, get_tags_admin_page, get_terms, handle_404_simple, health_check, list_api_keys,
+    list_articles, list_media, list_profiles, list_user_drafts, login_user, mobile_upload_article,
+    register_user, search_articles, unfavorite_article, unfollow_user, update_article,
+    update_category, update_current_user, update_media_metadata, update_tag, upload_media,
 };
 use crate::state::AppState;
 use crate::telemetry::MakeRequestUuid;
@@ -86,6 +86,7 @@ impl App {
             .route("/admin/categories", get(get_categories_admin_page))
             .route("/admin/api-keys", get(get_api_keys_admin_page))
             .route("/admin/media", get(get_media_library_page))
+            .route("/admin/drafts", get(get_drafts_admin_page))
             // API routes
             .route("/api/users", post(register_user))
             .route("/api/users/login", post(login_user))
@@ -98,6 +99,7 @@ impl App {
             )
             .route("/api/articles", post(create_article).get(list_articles))
             .route("/api/articles/feed", get(get_articles_feed))
+            .route("/api/articles/drafts", get(list_user_drafts))
             .route(
                 "/api/articles/{slug}",
                 get(get_article).put(update_article).delete(delete_article),

--- a/static/js/drafts.js
+++ b/static/js/drafts.js
@@ -1,0 +1,224 @@
+// drafts.js - Draft articles management functionality
+
+/**
+ * Drafts manager for handling draft article operations
+ */
+class DraftsManager {
+    constructor() {
+        this.publishModal = null;
+        this.deleteModal = null;
+        this.currentSlug = null;
+        this.currentTitle = null;
+        this.init();
+    }
+
+    init() {
+        this.setupModals();
+        this.setupPublishButtons();
+        this.setupDeleteButtons();
+    }
+
+    /**
+     * Setup Bootstrap modals
+     */
+    setupModals() {
+        const publishModalEl = document.getElementById('publishModal');
+        const deleteModalEl = document.getElementById('deleteModal');
+
+        if (publishModalEl) {
+            this.publishModal = new bootstrap.Modal(publishModalEl);
+            document.getElementById('confirmPublishBtn')?.addEventListener('click', () => {
+                this.publishDraft(this.currentSlug);
+            });
+        }
+
+        if (deleteModalEl) {
+            this.deleteModal = new bootstrap.Modal(deleteModalEl);
+            document.getElementById('confirmDeleteBtn')?.addEventListener('click', () => {
+                this.deleteDraft(this.currentSlug);
+            });
+        }
+    }
+
+    /**
+     * Setup publish button event listeners
+     */
+    setupPublishButtons() {
+        document.querySelectorAll('.publish-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const button = e.currentTarget;
+                this.currentSlug = button.getAttribute('data-slug');
+                this.currentTitle = button.getAttribute('data-title');
+
+                const titleEl = document.getElementById('publishArticleTitle');
+                if (titleEl) {
+                    titleEl.textContent = this.currentTitle;
+                }
+
+                this.publishModal?.show();
+            });
+        });
+    }
+
+    /**
+     * Setup delete button event listeners
+     */
+    setupDeleteButtons() {
+        document.querySelectorAll('.delete-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                const button = e.currentTarget;
+                this.currentSlug = button.getAttribute('data-slug');
+                this.currentTitle = button.getAttribute('data-title');
+
+                const titleEl = document.getElementById('deleteArticleTitle');
+                if (titleEl) {
+                    titleEl.textContent = this.currentTitle;
+                }
+
+                this.deleteModal?.show();
+            });
+        });
+    }
+
+    /**
+     * Publish a draft article
+     */
+    async publishDraft(slug) {
+        const token = getAuthToken();
+        if (!token) {
+            showError('Authentication required');
+            return;
+        }
+
+        try {
+            // Update the article to set draft = false
+            const response = await fetch(`/api/articles/${slug}`, {
+                method: 'PUT',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    article: {
+                        draft: false
+                    }
+                })
+            });
+
+            if (response.ok) {
+                showSuccess('Article published successfully');
+                this.publishModal?.hide();
+
+                // Remove the draft row from the table
+                const draftRow = document.querySelector(`tr[data-slug="${slug}"]`);
+                if (draftRow) {
+                    // Fade out animation
+                    draftRow.style.transition = 'opacity 0.3s';
+                    draftRow.style.opacity = '0';
+                    setTimeout(() => {
+                        draftRow.remove();
+
+                        // Check if there are any drafts left
+                        const remainingDrafts = document.querySelectorAll('#draftsTable tbody tr');
+                        if (remainingDrafts.length === 0) {
+                            // Reload the page to show the "no drafts" message
+                            setTimeout(() => {
+                                window.location.reload();
+                            }, 1000);
+                        }
+                    }, 300);
+                }
+            } else {
+                const errorData = await response.json();
+                showError(errorData.message || 'Failed to publish article');
+            }
+        } catch (error) {
+            console.error('Error publishing article:', error);
+            showError('Network error. Please try again.');
+        }
+    }
+
+    /**
+     * Delete a draft article
+     */
+    async deleteDraft(slug) {
+        const token = getAuthToken();
+        if (!token) {
+            showError('Authentication required');
+            return;
+        }
+
+        try {
+            const response = await fetch(`/api/articles/${slug}`, {
+                method: 'DELETE',
+                headers: {
+                    'Authorization': `Bearer ${token}`
+                }
+            });
+
+            if (response.ok || response.status === 204) {
+                showSuccess('Draft deleted successfully');
+                this.deleteModal?.hide();
+
+                // Remove the draft row from the table
+                const draftRow = document.querySelector(`tr[data-slug="${slug}"]`);
+                if (draftRow) {
+                    // Fade out animation
+                    draftRow.style.transition = 'opacity 0.3s';
+                    draftRow.style.opacity = '0';
+                    setTimeout(() => {
+                        draftRow.remove();
+
+                        // Check if there are any drafts left
+                        const remainingDrafts = document.querySelectorAll('#draftsTable tbody tr');
+                        if (remainingDrafts.length === 0) {
+                            // Reload the page to show the "no drafts" message
+                            setTimeout(() => {
+                                window.location.reload();
+                            }, 1000);
+                        }
+                    }, 300);
+                }
+            } else {
+                const errorData = await response.json();
+                showError(errorData.message || 'Failed to delete draft');
+            }
+        } catch (error) {
+            console.error('Error deleting draft:', error);
+            showError('Network error. Please try again.');
+        }
+    }
+
+    /**
+     * Show notification message
+     */
+    showNotification(message, type = 'info') {
+        const notification = document.createElement('div');
+        notification.className = `alert alert-${type} alert-dismissible fade show position-fixed top-0 start-50 translate-middle-x mt-3`;
+        notification.style.zIndex = '9999';
+        notification.innerHTML = `
+            ${message}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        `;
+
+        document.body.appendChild(notification);
+
+        // Auto-dismiss after 5 seconds
+        setTimeout(() => {
+            if (notification.parentNode) {
+                notification.remove();
+            }
+        }, 5000);
+    }
+}
+
+// Initialize when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    // Only initialize on drafts page
+    if (document.querySelector('#draftsTable')) {
+        new DraftsManager();
+    }
+});
+
+// Export for manual initialization
+window.DraftsManager = DraftsManager;

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -131,6 +131,23 @@
 </div>
 
 <div class="row">
+    <!-- Draft Articles Card -->
+    <div class="col-md-6 col-lg-4 mb-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">
+                    <i class="fas fa-file-alt"></i> Draft Articles
+                </h5>
+                <p class="card-text">
+                    Manage your draft articles. Review, edit, publish, or delete drafts before making them public.
+                </p>
+                <a href="/admin/drafts" class="btn btn-primary">
+                    <i class="fas fa-file-alt"></i> Manage Drafts
+                </a>
+            </div>
+        </div>
+    </div>
+
     <!-- Manage Tags Card -->
     <div class="col-md-6 col-lg-4 mb-4">
         <div class="card h-100">

--- a/templates/admin/drafts.html
+++ b/templates/admin/drafts.html
@@ -1,0 +1,178 @@
+{% extends "base.html" %}
+
+{% block title %}Draft Articles - CrustyRustacean Dev Blog{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="card shadow mb-4">
+                <div class="card-header">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <h2 class="card-title mb-0">
+                            <i class="fas fa-file-alt me-2"></i>
+                            Draft Articles
+                        </h2>
+                        <div>
+                            <a href="/editor" class="btn btn-primary">
+                                <i class="fas fa-plus me-2"></i>
+                                New Draft
+                            </a>
+                            <a href="/admin" class="btn btn-secondary">
+                                <i class="fas fa-arrow-left me-2"></i>
+                                Back to Dashboard
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    {% if drafts and drafts|length > 0 %}
+                        <div class="alert alert-info" role="alert">
+                            <i class="fas fa-info-circle me-2"></i>
+                            You have <strong>{{ drafts|length }}</strong> draft article{% if drafts|length != 1 %}s{% endif %}. Draft articles are only visible to you and won't appear in public listings.
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover" id="draftsTable">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <th scope="col">Title</th>
+                                        <th scope="col">Description</th>
+                                        <th scope="col">Tags</th>
+                                        <th scope="col">Created</th>
+                                        <th scope="col">Last Updated</th>
+                                        <th scope="col">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for draft in drafts %}
+                                    <tr data-slug="{{ draft.slug }}">
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                <span class="badge bg-warning text-dark me-2">
+                                                    <i class="fas fa-file-alt"></i> Draft
+                                                </span>
+                                                <strong>{{ draft.title }}</strong>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <small class="text-muted">{{ draft.description|truncate(100) }}</small>
+                                        </td>
+                                        <td>
+                                            {% if draft.tagList and draft.tagList|length > 0 %}
+                                                <div class="d-flex flex-wrap gap-1">
+                                                    {% for tag in draft.tagList %}
+                                                        <span class="badge bg-secondary">{{ tag }}</span>
+                                                    {% endfor %}
+                                                </div>
+                                            {% else %}
+                                                <span class="text-muted">No tags</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            <small>{{ draft.createdAt }}</small>
+                                        </td>
+                                        <td>
+                                            <small>{{ draft.updatedAt }}</small>
+                                        </td>
+                                        <td>
+                                            <div class="btn-group" role="group" aria-label="Draft actions">
+                                                <button type="button" class="btn btn-sm btn-success publish-btn"
+                                                        title="Publish Draft"
+                                                        data-slug="{{ draft.slug }}"
+                                                        data-title="{{ draft.title }}">
+                                                    <i class="fas fa-check"></i>
+                                                </button>
+                                                <a href="/articles/{{ draft.slug }}" class="btn btn-sm btn-outline-info" title="Preview Draft">
+                                                    <i class="fas fa-eye"></i>
+                                                </a>
+                                                <a href="/editor/{{ draft.slug }}" class="btn btn-sm btn-outline-warning" title="Edit Draft">
+                                                    <i class="fas fa-edit"></i>
+                                                </a>
+                                                <button type="button" class="btn btn-sm btn-outline-danger delete-btn"
+                                                        title="Delete Draft"
+                                                        data-slug="{{ draft.slug }}"
+                                                        data-title="{{ draft.title }}">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% else %}
+                        <div class="text-center py-5">
+                            <i class="fas fa-file-alt fa-5x text-muted mb-3"></i>
+                            <h3 class="text-muted mb-3">No Drafts Yet</h3>
+                            <p class="text-muted mb-4">Start writing a draft article to work on it before publishing.</p>
+                            <a href="/editor" class="btn btn-primary btn-lg">
+                                <i class="fas fa-plus me-2"></i>
+                                Create Your First Draft
+                            </a>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Publish Confirmation Modal -->
+<div class="modal fade" id="publishModal" tabindex="-1" aria-labelledby="publishModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="publishModalLabel">Publish Draft</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-success" role="alert">
+                    <i class="fas fa-check-circle me-2"></i>
+                    <strong>Ready to publish!</strong>
+                </div>
+                <p>Are you sure you want to publish <strong id="publishArticleTitle"></strong>?</p>
+                <p class="text-muted small">Once published, this article will be visible to all visitors.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-success" id="confirmPublishBtn">
+                    <i class="fas fa-check me-2"></i>
+                    Publish Article
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm Deletion</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-warning" role="alert">
+                    <i class="fas fa-exclamation-triangle me-2"></i>
+                    <strong>Warning!</strong> This action cannot be undone.
+                </div>
+                <p>Are you sure you want to delete the draft <strong id="deleteArticleTitle"></strong>?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirmDeleteBtn">
+                    <i class="fas fa-trash me-2"></i>
+                    Delete Draft
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="/static/js/utils.js"></script>
+<script src="/static/js/drafts.js"></script>
+{% endblock %}

--- a/tests/api/drafts.rs
+++ b/tests/api/drafts.rs
@@ -1,0 +1,408 @@
+// tests/api/drafts.rs - Integration tests for draft article functionality
+
+use crate::helpers::{assert_body_contains, spawn_app, TestArticleBuilder, TestUserBuilder, HtmlResponseValidator};
+
+#[tokio::test]
+async fn test_create_draft_article() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Create a draft article
+    let response = app
+        .client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "My Draft Article",
+                "description": "This is a draft",
+                "body": "Draft content",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 201);
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let article = &body["article"];
+    assert_eq!(article["draft"], true);
+    assert_eq!(article["title"], "My Draft Article");
+}
+
+#[tokio::test]
+async fn test_list_user_drafts_api() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Create multiple drafts
+    app.client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Draft 1",
+                "description": "First draft",
+                "body": "Content 1",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft 1");
+
+    app.client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Draft 2",
+                "description": "Second draft",
+                "body": "Content 2",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft 2");
+
+    // Create a published article (should not appear in drafts)
+    app.create_article_simple(&token, "Published Article").await;
+
+    // List drafts via API
+    let response = app
+        .client
+        .get(format!("{}/api/articles/drafts", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 200);
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let articles = body["articles"].as_array().expect("Expected articles array");
+
+    assert_eq!(articles.len(), 2);
+    assert_eq!(body["articlesCount"], 2);
+
+    // Verify both drafts are present
+    let titles: Vec<&str> = articles
+        .iter()
+        .map(|a| a["title"].as_str().unwrap())
+        .collect();
+    assert!(titles.contains(&"Draft 1"));
+    assert!(titles.contains(&"Draft 2"));
+    assert!(!titles.contains(&"Published Article"));
+}
+
+#[tokio::test]
+async fn test_drafts_admin_page() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Create a draft
+    app.client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Test Draft",
+                "description": "Draft description",
+                "body": "Draft body",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft");
+
+    // Access drafts admin page
+    let response = app
+        .client
+        .get(format!("{}/admin/drafts", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 200);
+
+    let body = response.assert_html_response().await;
+    assert_body_contains(&body, &[
+        "Draft Articles",
+        "Test Draft",
+        "Draft description",
+        "testuser",
+    ]);
+}
+
+#[tokio::test]
+async fn test_publish_draft() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Create a draft
+    let response = app
+        .client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Draft to Publish",
+                "description": "Will be published",
+                "body": "Content",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft");
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let slug = body["article"]["slug"].as_str().unwrap();
+
+    // Publish the draft
+    let response = app
+        .client
+        .put(format!("{}/api/articles/{}", &app.address, slug))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "draft": false
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to publish draft");
+
+    assert_eq!(response.status(), 200);
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    assert_eq!(body["article"]["draft"], false);
+
+    // Verify it no longer appears in drafts list
+    let response = app
+        .client
+        .get(format!("{}/api/articles/drafts", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let articles = body["articles"].as_array().expect("Expected articles array");
+    assert_eq!(articles.len(), 0);
+}
+
+#[tokio::test]
+async fn test_draft_visibility_author_only() {
+    let app = spawn_app().await;
+    let alice_token = app.register_user("alice", "alice@example.com", "password").await;
+    let bob_token = app.register_user("bob", "bob@example.com", "password").await;
+
+    // Alice creates a draft
+    let response = app
+        .client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", alice_token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Alice's Draft",
+                "description": "Private draft",
+                "body": "Secret content",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft");
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let slug = body["article"]["slug"].as_str().unwrap();
+
+    // Alice can view her own draft
+    let response = app
+        .client
+        .get(format!("{}/api/articles/{}", &app.address, slug))
+        .header("Authorization", format!("Bearer {}", alice_token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 200);
+
+    // Bob cannot view Alice's draft
+    let response = app
+        .client
+        .get(format!("{}/api/articles/{}", &app.address, slug))
+        .header("Authorization", format!("Bearer {}", bob_token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 404);
+
+    // Anonymous users cannot view the draft
+    let response = app
+        .client
+        .get(format!("{}/api/articles/{}", &app.address, slug))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 404);
+
+    // Bob's drafts list should be empty
+    let response = app
+        .client
+        .get(format!("{}/api/articles/drafts", &app.address))
+        .header("Authorization", format!("Bearer {}", bob_token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let articles = body["articles"].as_array().expect("Expected articles array");
+    assert_eq!(articles.len(), 0);
+}
+
+#[tokio::test]
+async fn test_draft_not_in_public_listing() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Create a draft and a published article
+    app.client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Draft Article",
+                "description": "Should not appear",
+                "body": "Content",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft");
+
+    app.create_article_simple(&token, "Published Article").await;
+
+    // Check public articles list
+    let response = app
+        .client
+        .get(format!("{}/api/articles", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 200);
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let articles = body["articles"].as_array().expect("Expected articles array");
+
+    // Only the published article should appear
+    assert_eq!(articles.len(), 1);
+    assert_eq!(articles[0]["title"], "Published Article");
+}
+
+#[tokio::test]
+async fn test_delete_draft() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Create a draft
+    let response = app
+        .client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&serde_json::json!({
+            "article": {
+                "title": "Draft to Delete",
+                "description": "Will be deleted",
+                "body": "Content",
+                "draft": true
+            }
+        }))
+        .send()
+        .await
+        .expect("Failed to create draft");
+
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let slug = body["article"]["slug"].as_str().unwrap();
+
+    // Delete the draft
+    let response = app
+        .client
+        .delete(format!("{}/api/articles/{}", &app.address, slug))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to delete draft");
+
+    assert_eq!(response.status(), 204);
+
+    // Verify it's deleted
+    let response = app
+        .client
+        .get(format!("{}/api/articles/{}", &app.address, slug))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 404);
+}
+
+#[tokio::test]
+async fn test_empty_drafts_page() {
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Access drafts page with no drafts
+    let response = app
+        .client
+        .get(format!("{}/admin/drafts", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 200);
+
+    let body = response.assert_html_response().await;
+    assert_body_contains(&body, &[
+        "Draft Articles",
+        "No Drafts Yet",
+        "Create Your First Draft",
+    ]);
+}
+
+#[tokio::test]
+async fn test_drafts_require_authentication() {
+    let app = spawn_app().await;
+
+    // Try to access drafts API without authentication
+    let response = app
+        .client
+        .get(format!("{}/api/articles/drafts", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 401);
+
+    // Try to access drafts page without authentication
+    let response = app
+        .client
+        .get(format!("{}/admin/drafts", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status(), 401);
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -7,6 +7,7 @@ mod auth;
 mod authors;
 mod categories;
 mod comments;
+mod drafts;
 mod favorites;
 mod feed;
 mod feed_page;


### PR DESCRIPTION
Implement a comprehensive drafts management system that allows authors to review and manage their draft articles before publication.

Backend Changes:
- Add list_user_drafts() endpoint to fetch draft articles for authenticated users
- Add get_drafts_admin_page() handler for the drafts management UI
- Update database schema to include draft column in articles table (default 0)
- Add /api/articles/drafts API route for listing user drafts
- Add /admin/drafts route for the drafts management page

Frontend Changes:
- Create /templates/admin/drafts.html template with:
  - Table view of draft articles with title, description, tags, and timestamps
  - Publish button to make drafts public
  - Edit, preview, and delete actions for each draft
  - Empty state for users with no drafts
- Create /static/js/drafts.js JavaScript module with:
  - Publish draft functionality (updates draft status to false)
  - Delete draft functionality
  - Bootstrap modal confirmations for actions
  - Real-time UI updates with fade animations
- Add "Draft Articles" card to admin dashboard for easy access

Testing:
- Comprehensive integration tests in tests/api/drafts.rs covering:
  - Creating draft articles
  - Listing user drafts (API and page)
  - Publishing drafts
  - Draft visibility (author-only access)
  - Drafts excluded from public listings
  - Deleting drafts
  - Authentication requirements
  - Empty drafts state

Features:
- Only article authors can see their own drafts
- Drafts are excluded from public article listings
- One-click publishing from drafts panel
- Preview drafts before publishing
- Edit drafts directly from panel
- Delete unwanted drafts with confirmation

## Summary

This PR adds **Phase 0.5: Theme Foundation** to the project plan based on the insight that theming should be established early to prevent technical debt.

## Changes

### PROJECT_PLAN.md
- Updated to version 1.1.0
- Added Phase 0.5 section between Phase 0 (Quick Wins) and Phase 1 (Content Management)
- Updated timeline from 6-7 months to 7-8 months
- Renumbered all issues from #3-#19 (Phase 0.5 becomes Issue #2)
- Added Phase 0.5 to Success Metrics
- Updated revision history and next actions

### New Phase 0.5: Theme Foundation (1-2 weeks)

**Goals:**
- Move templates to `themes/default/` directory structure
- Create theme metadata system (`theme.toml`)
- Build backend theme loader (`src/lib/theme.rs`)
- Extract reusable components (navbar, footer, card, button, form)
- Create semantic CSS classes abstracting Bootstrap
- Use CSS custom properties for theme variables

**Why This Matters:**

Currently, Bootstrap classes are hardcoded throughout all 22+ templates. If we build Phase 1 features (media library, settings, admin UIs) with hardcoded Bootstrap, we'll need to refactor everything when implementing the full theme system.

By establishing theme foundation NOW:
- ✅ One-time refactor instead of continuous rework
- ✅ All Phase 1 features built theme-agnostic from day one
- ✅ Easy to switch from Bootstrap to Tailwind/custom CSS later
- ✅ Better developer experience with reusable components
- ✅ Aligns with WordPress model (themes are foundational)
- ✅ Future-proof architecture

### New Issue Template

**File:** `.github/issues/phase0/issue-02-theme-foundation.md`

Comprehensive 2-week implementation plan including:
- Week 1: Structure, migration, backend loader
- Week 2: Components, CSS abstraction, documentation
- Complete code examples
- Testing requirements
- Success criteria

## Implementation Order

1. **Phase 0:** Tag Editing (2 hours) - Quick win
2. **Phase 0.5:** Theme Foundation (1-2 weeks) - **NEW** ⭐
3. **Phase 1:** Media Library, Drafts, Roles, Settings (2 months)
4. **Phase 2:** Pages, Categories, Revisions (2 months)
5. **Phase 3:** Full Theme System, Menus, Widgets (2 months)
6. **Phase 4:** Plugins, Advanced Features (ongoing)

## Related Documents

- `TAG_EDITING_PLAN.md` - Existing detailed plan for Phase 0
- `CODEBASE_INDEX.md` - Current codebase documentation
- `.github/issues/phase1/` - Phase 1 issue templates (already created)

## Next Steps

1. Review and merge this PR
2. Create GitHub issue from `.github/issues/phase0/issue-02-theme-foundation.md`
3. Implement tag editing (2 hours)
4. Implement theme foundation (1-2 weeks)
5. Begin Phase 1 with theme-agnostic approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
