### PR TITLE
feat: add draft save functionality to article editor

### DIFF
--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -8,17 +8,36 @@ document.addEventListener('DOMContentLoaded', function() {
     const submitBtn = document.getElementById('submitBtn');
     const submitText = document.getElementById('submitText');
     const loadingText = document.getElementById('loadingText');
+    const saveDraftBtn = document.getElementById('saveDraftBtn');
+    const draftText = document.getElementById('draftText');
+    const draftLoadingText = document.getElementById('draftLoadingText');
 
+    // Handle save draft button
+    if (saveDraftBtn) {
+        saveDraftBtn.addEventListener('click', async function(e) {
+            e.preventDefault();
+            await saveArticle(true); // true = save as draft
+        });
+    }
+
+    // Handle publish/update button
     articleForm.addEventListener('submit', async function(e) {
         e.preventDefault();
-        
-        // Show loading state
-        submitBtn.disabled = true;
-        submitText.classList.add('d-none');
-        loadingText.classList.remove('d-none');
+        await saveArticle(false); // false = publish
+    });
 
-        const formData = new FormData(this);
-        
+    async function saveArticle(asDraft) {
+        const targetBtn = asDraft ? saveDraftBtn : submitBtn;
+        const targetText = asDraft ? draftText : submitText;
+        const targetLoadingText = asDraft ? draftLoadingText : loadingText;
+
+        // Show loading state
+        targetBtn.disabled = true;
+        targetText.classList.add('d-none');
+        targetLoadingText.classList.remove('d-none');
+
+        const formData = new FormData(articleForm);
+
         // Parse tags
         const tagsInput = formData.get('tags');
         const tagList = tagsInput ? tagsInput.split(',').map(tag => tag.trim()).filter(tag => tag.length > 0) : [];
@@ -31,7 +50,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 title: formData.get('title'),
                 description: formData.get('description'),
                 body: formData.get('body'),
-                tagList: tagList
+                tagList: tagList,
+                draft: asDraft
             }
         };
 
@@ -43,16 +63,16 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             // Get auth token from localStorage or cookies
             const token = localStorage.getItem('authToken') || getAuthTokenFromCookies();
-            
+
             if (!token) {
-                showError('You must be logged in to publish articles.');
-                resetSubmitButton();
+                showError('You must be logged in to save articles.');
+                resetButton(targetBtn, targetText, targetLoadingText);
                 return;
             }
 
             const isEditMode = articleForm.getAttribute('data-edit-mode') === 'true';
             const articleSlug = articleForm.getAttribute('data-article-slug');
-            
+
             const url = isEditMode ? `/api/articles/${articleSlug}` : '/api/articles';
             const method = isEditMode ? 'PUT' : 'POST';
 
@@ -67,30 +87,46 @@ document.addEventListener('DOMContentLoaded', function() {
 
             if (response.ok) {
                 const data = await response.json();
+
                 // Show success message
-                const successMessage = isEditMode ? 'Article updated successfully!' : 'Article published successfully!';
+                let successMessage;
+                if (asDraft) {
+                    successMessage = isEditMode ? 'Draft updated successfully!' : 'Draft saved successfully!';
+                } else {
+                    successMessage = isEditMode ? 'Article published successfully!' : 'Article published successfully!';
+                }
                 showSuccess(successMessage);
-                
-                // Redirect to the article page after a short delay
+
+                // Redirect based on draft status
                 setTimeout(() => {
-                    window.location.href = `/articles/${data.article.slug}`;
+                    if (asDraft) {
+                        // Redirect to drafts admin page
+                        window.location.href = '/admin/drafts';
+                    } else {
+                        // Redirect to the published article page
+                        window.location.href = `/articles/${data.article.slug}`;
+                    }
                 }, 1500);
             } else {
                 const errorData = await response.json();
-                const errorMessage = isEditMode ? 'Failed to update article. Please try again.' : 'Failed to publish article. Please try again.';
+                const errorMessage = asDraft ? 'Failed to save draft. Please try again.' : 'Failed to publish article. Please try again.';
                 showError(errorData.message || errorMessage);
-                resetSubmitButton();
+                resetButton(targetBtn, targetText, targetLoadingText);
             }
         } catch (error) {
             showError('Network error. Please check your connection and try again.');
-            resetSubmitButton();
+            resetButton(targetBtn, targetText, targetLoadingText);
         }
-    });
+    }
+
+    function resetButton(btn, textEl, loadingEl) {
+        btn.disabled = false;
+        textEl.classList.remove('d-none');
+        loadingEl.classList.add('d-none');
+    }
 
     function resetSubmitButton() {
-        submitBtn.disabled = false;
-        submitText.classList.remove('d-none');
-        loadingText.classList.add('d-none');
+        resetButton(submitBtn, submitText, loadingText);
     }
 
     function getAuthTokenFromCookies() {

--- a/templates/articles/editor.html
+++ b/templates/articles/editor.html
@@ -11,6 +11,12 @@
                     <i class="fas fa-pen-fancy fa-3x text-primary mb-3"></i>
                     <h2 class="card-title">{{ title | default(value="Write New Article") }}</h2>
                     <p class="text-muted">Share your knowledge with the community</p>
+                    {% if article and article.draft %}
+                    <div class="alert alert-warning d-inline-block">
+                        <i class="fas fa-file-alt me-2"></i>
+                        <strong>Draft Mode</strong> - This article is not yet published
+                    </div>
+                    {% endif %}
                 </div>
 
                 {% if error %}
@@ -20,7 +26,11 @@
                     </div>
                 {% endif %}
 
-                <form id="articleForm" method="POST" data-edit-mode="{{ is_edit | default(value=false) }}" {% if is_edit %}data-article-slug="{{ article_slug }}"{% endif %}>
+                <form id="articleForm" method="POST"
+                      data-edit-mode="{{ is_edit | default(value=false) }}"
+                      {% if is_edit %}data-article-slug="{{ article_slug }}"{% endif %}
+                      {% if article %}data-is-draft="{{ article.draft }}"{% endif %}>
+
                     <div class="mb-4">
                         <label for="title" class="form-label">Article Title</label>
                         <div class="input-group">
@@ -107,12 +117,20 @@
                             <i class="fas fa-times me-2"></i>
                             Cancel
                         </a>
+                        <button type="button" class="btn btn-outline-primary btn-lg me-md-2" id="saveDraftBtn">
+                            <i class="fas fa-save me-2"></i>
+                            <span id="draftText">Save as Draft</span>
+                            <span id="draftLoadingText" class="d-none">
+                                <i class="fas fa-spinner fa-spin me-2"></i>
+                                Saving...
+                            </span>
+                        </button>
                         <button type="submit" class="btn btn-primary btn-lg" id="submitBtn">
                             <i class="fas fa-paper-plane me-2"></i>
-                            <span id="submitText">{% if is_edit %}Update Article{% else %}Publish Article{% endif %}</span>
+                            <span id="submitText">{% if is_edit %}{% if article and article.draft %}Publish{% else %}Update{% endif %}{% else %}Publish{% endif %}</span>
                             <span id="loadingText" class="d-none">
                                 <i class="fas fa-spinner fa-spin me-2"></i>
-                                {% if is_edit %}Updating...{% else %}Publishing...{% endif %}
+                                {% if is_edit %}{% if article and article.draft %}Publishing...{% else %}Updating...{% endif %}{% else %}Publishing...{% endif %}
                             </span>
                         </button>
                     </div>


### PR DESCRIPTION
Implement complete draft workflow in the editor interface, allowing authors to save articles as drafts and return to them later via the drafts admin panel.

Editor Template Changes (templates/articles/editor.html):
- Add "Draft Mode" warning badge when editing an existing draft
- Add "Save as Draft" button alongside the Publish button
- Update Publish button text to show "Publish" when editing a draft
- Add data-is-draft attribute to form for JavaScript access
- Distinct loading states for both buttons

Editor JavaScript Changes (static/js/editor.js):
- Refactor form submission into reusable saveArticle(asDraft) function
- Add draft save button event handler
- Include draft: true/false in article data payload
- Smart redirection:
  - Drafts redirect to /admin/drafts for further editing
  - Published articles redirect to the article page
- Context-aware success messages based on draft status
- Support for converting drafts to published articles

User Experience:
- Authors can now click "Save as Draft" to save work-in-progress
- Drafts are clearly labeled with warning badge
- Publish button on draft changes to "Publish" (not "Update")
- Seamless workflow: Write → Save Draft → Review in Admin → Publish

This completes the drafts feature by connecting the editor to the drafts management panel created earlier.

## Summary

This PR adds **Phase 0.5: Theme Foundation** to the project plan based on the insight that theming should be established early to prevent technical debt.

## Changes

### PROJECT_PLAN.md
- Updated to version 1.1.0
- Added Phase 0.5 section between Phase 0 (Quick Wins) and Phase 1 (Content Management)
- Updated timeline from 6-7 months to 7-8 months
- Renumbered all issues from #3-#19 (Phase 0.5 becomes Issue #2)
- Added Phase 0.5 to Success Metrics
- Updated revision history and next actions

### New Phase 0.5: Theme Foundation (1-2 weeks)

**Goals:**
- Move templates to `themes/default/` directory structure
- Create theme metadata system (`theme.toml`)
- Build backend theme loader (`src/lib/theme.rs`)
- Extract reusable components (navbar, footer, card, button, form)
- Create semantic CSS classes abstracting Bootstrap
- Use CSS custom properties for theme variables

**Why This Matters:**

Currently, Bootstrap classes are hardcoded throughout all 22+ templates. If we build Phase 1 features (media library, settings, admin UIs) with hardcoded Bootstrap, we'll need to refactor everything when implementing the full theme system.

By establishing theme foundation NOW:
- ✅ One-time refactor instead of continuous rework
- ✅ All Phase 1 features built theme-agnostic from day one
- ✅ Easy to switch from Bootstrap to Tailwind/custom CSS later
- ✅ Better developer experience with reusable components
- ✅ Aligns with WordPress model (themes are foundational)
- ✅ Future-proof architecture

### New Issue Template

**File:** `.github/issues/phase0/issue-02-theme-foundation.md`

Comprehensive 2-week implementation plan including:
- Week 1: Structure, migration, backend loader
- Week 2: Components, CSS abstraction, documentation
- Complete code examples
- Testing requirements
- Success criteria

## Implementation Order

1. **Phase 0:** Tag Editing (2 hours) - Quick win
2. **Phase 0.5:** Theme Foundation (1-2 weeks) - **NEW** ⭐
3. **Phase 1:** Media Library, Drafts, Roles, Settings (2 months)
4. **Phase 2:** Pages, Categories, Revisions (2 months)
5. **Phase 3:** Full Theme System, Menus, Widgets (2 months)
6. **Phase 4:** Plugins, Advanced Features (ongoing)

## Related Documents

- `TAG_EDITING_PLAN.md` - Existing detailed plan for Phase 0
- `CODEBASE_INDEX.md` - Current codebase documentation
- `.github/issues/phase1/` - Phase 1 issue templates (already created)

## Next Steps

1. Review and merge this PR
2. Create GitHub issue from `.github/issues/phase0/issue-02-theme-foundation.md`
3. Implement tag editing (2 hours)
4. Implement theme foundation (1-2 weeks)
5. Begin Phase 1 with theme-agnostic approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
