### PR TITLE
fix: Apply Cache-Control headers only to static assets, not globally

### DIFF
--- a/src/lib/startup.rs
+++ b/src/lib/startup.rs
@@ -144,9 +144,18 @@ impl App {
             .route("/api/search", get(search_articles))
             .nest_service(
                 "/static",
-                ServeDir::new("static")
-                    .precompressed_gzip()
-                    .precompressed_br()
+                // Static file service with aggressive caching for versioned assets
+                tower::ServiceBuilder::new()
+                    .layer(SetResponseHeaderLayer::if_not_present(
+                        header::CACHE_CONTROL,
+                        HeaderValue::from_static("public, max-age=31536000, immutable"),
+                    ))
+                    .service(
+                        ServeDir::new("static")
+                            .precompressed_gzip()
+                            .precompressed_br()
+                            .append_index_html_on_directories(false)
+                    )
             )
             .fallback(handle_404_simple)
             .with_state(state)
@@ -169,10 +178,6 @@ impl App {
             .layer(SetResponseHeaderLayer::if_not_present(
                 header::STRICT_TRANSPORT_SECURITY,
                 HeaderValue::from_static("max-age=31536000; includeSubDomains"),
-            ))
-            .layer(SetResponseHeaderLayer::if_not_present(
-                header::CACHE_CONTROL,
-                HeaderValue::from_static("public, max-age=31536000, immutable"),
             ))
     }
 


### PR DESCRIPTION
CRITICAL FIX: The previous implementation applied aggressive caching headers (max-age=31536000) to ALL responses including HTML pages and API endpoints, which broke authentication state persistence between page navigations.

Root Cause Analysis:
- Cache-Control headers were applied globally via .layer() on the main router
- This caused browsers to cache HTML pages, login pages, and API responses
- Users would see stale pages and lose authentication state between navigations
- Versioned assets (?v=2.9.0) were working, but pages were cached

Changes:
- REMOVED: Global Cache-Control layer from main router (lines 173-176)
- ADDED: Route-specific Cache-Control only for /static assets
- Used tower::ServiceBuilder to wrap ServeDir with caching middleware
- Static assets now get: Cache-Control: public, max-age=31536000, immutable
- HTML/API responses: No Cache-Control header (browser default behavior)

Best Practices Implemented:
✓ Static assets (CSS/JS/images): Aggressive caching with versioned URLs ✓ HTML pages: No explicit caching (allows browser heuristics) ✓ API responses: No caching (default behavior prevents stale data) ✓ Route-specific middleware instead of global application

Impact:
- Authentication state now persists correctly between page loads
- Users stay logged in when navigating the site
- Static assets still benefit from long-term caching via versioning
- No more stale page content being served from cache

Testing:
- All 12 template_rendering tests pass
- Code compiles without errors
- Ready for immediate deployment to fix production issue

## Summary

This PR adds **Phase 0.5: Theme Foundation** to the project plan based on the insight that theming should be established early to prevent technical debt.

## Changes

### PROJECT_PLAN.md
- Updated to version 1.1.0
- Added Phase 0.5 section between Phase 0 (Quick Wins) and Phase 1 (Content Management)
- Updated timeline from 6-7 months to 7-8 months
- Renumbered all issues from #3-#19 (Phase 0.5 becomes Issue #2)
- Added Phase 0.5 to Success Metrics
- Updated revision history and next actions

### New Phase 0.5: Theme Foundation (1-2 weeks)

**Goals:**
- Move templates to `themes/default/` directory structure
- Create theme metadata system (`theme.toml`)
- Build backend theme loader (`src/lib/theme.rs`)
- Extract reusable components (navbar, footer, card, button, form)
- Create semantic CSS classes abstracting Bootstrap
- Use CSS custom properties for theme variables

**Why This Matters:**

Currently, Bootstrap classes are hardcoded throughout all 22+ templates. If we build Phase 1 features (media library, settings, admin UIs) with hardcoded Bootstrap, we'll need to refactor everything when implementing the full theme system.

By establishing theme foundation NOW:
- ✅ One-time refactor instead of continuous rework
- ✅ All Phase 1 features built theme-agnostic from day one
- ✅ Easy to switch from Bootstrap to Tailwind/custom CSS later
- ✅ Better developer experience with reusable components
- ✅ Aligns with WordPress model (themes are foundational)
- ✅ Future-proof architecture

### New Issue Template

**File:** `.github/issues/phase0/issue-02-theme-foundation.md`

Comprehensive 2-week implementation plan including:
- Week 1: Structure, migration, backend loader
- Week 2: Components, CSS abstraction, documentation
- Complete code examples
- Testing requirements
- Success criteria

## Implementation Order

1. **Phase 0:** Tag Editing (2 hours) - Quick win
2. **Phase 0.5:** Theme Foundation (1-2 weeks) - **NEW** ⭐
3. **Phase 1:** Media Library, Drafts, Roles, Settings (2 months)
4. **Phase 2:** Pages, Categories, Revisions (2 months)
5. **Phase 3:** Full Theme System, Menus, Widgets (2 months)
6. **Phase 4:** Plugins, Advanced Features (ongoing)

## Related Documents

- `TAG_EDITING_PLAN.md` - Existing detailed plan for Phase 0
- `CODEBASE_INDEX.md` - Current codebase documentation
- `.github/issues/phase1/` - Phase 1 issue templates (already created)

## Next Steps

1. Review and merge this PR
2. Create GitHub issue from `.github/issues/phase0/issue-02-theme-foundation.md`
3. Implement tag editing (2 hours)
4. Implement theme foundation (1-2 weeks)
5. Begin Phase 1 with theme-agnostic approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
