### PR TITLE
fix: Switch lettre from native-tls to rustls-tls for Windows compatib…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,14 +1881,15 @@ dependencies = [
  "httpdate",
  "idna",
  "mime",
- "native-tls",
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
+ "rustls 0.23.35",
  "socket2 0.6.1",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "url",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -3160,6 +3161,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4.42", features = ["serde"] }
 dotenvy = "0.15.7"
 futures-util = "0.3.31"
 jsonwebtoken = { version = "10.2.0", features = ["use_pem", "rust_crypto"] }
-lettre = { version = "0.11.11", features = ["tokio1-native-tls", "smtp-transport", "pool", "hostname", "builder"] }
+lettre = { version = "0.11.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "pool", "hostname", "builder"] }
 libsql = { version = "0.9.27", features = ["serde"] }
 once_cell = "1.21.3"
 opendal = { version = "0.54.1", features = [ "services-s3", "services-fs"] }


### PR DESCRIPTION
…ility

Changed lettre email library to use rustls-tls instead of native-tls to fix Windows linker errors. Rustls is a pure Rust TLS implementation that doesn't require external OpenSSL libraries, making it fully cross-platform compatible.

Changes:
- Disabled default features on lettre (which include native-tls)
- Enabled tokio1-rustls-tls feature explicitly
- All tests still pass with rustls

This resolves Windows compilation errors while maintaining the same functionality on all platforms.