### PR TITLE
feat: Add trait-based email service with Mailtrap HTTP API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["registry", "env-filter"] }
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
+reqwest = { version = "0.12.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.12", features = [ "multipart", "json" ] }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,6 +1,7 @@
 // src/lib/config.rs
 
 // dependencies
+use crate::email::EmailConfig;
 use anyhow::{Result, anyhow};
 use shuttle_runtime::{CustomError, SecretStore};
 
@@ -13,6 +14,7 @@ pub struct AppConfig {
     pub override_stylesheet: String,
     pub app_version: String,
     pub allowed_origins: Vec<String>,
+    pub email: EmailConfig,
 }
 
 // implement the TryFrom trait for the AppConfig type
@@ -56,6 +58,17 @@ impl TryFrom<&SecretStore> for AppConfig {
                 ]
             });
 
+        // Load email configuration (all optional - falls back to logging sender)
+        let email = EmailConfig {
+            mailtrap_api_token: secrets.get("MAILTRAP_API_TOKEN").filter(|s| !s.is_empty()),
+            sender_email: secrets
+                .get("MAILTRAP_SENDER_EMAIL")
+                .unwrap_or_else(|| "noreply@example.com".to_string()),
+            sender_name: secrets
+                .get("MAILTRAP_SENDER_NAME")
+                .unwrap_or_else(|| "CrustyRustacean Dev Blog".to_string()),
+        };
+
         Ok(Self {
             jwt_secret,
             templates_dir,
@@ -63,6 +76,7 @@ impl TryFrom<&SecretStore> for AppConfig {
             override_stylesheet,
             app_version,
             allowed_origins,
+            email,
         })
     }
 }

--- a/src/lib/email.rs
+++ b/src/lib/email.rs
@@ -1,82 +1,802 @@
 // src/lib/email.rs
 
-use crate::ApiError;
-use tracing::info;
+//! Email sending service with trait-based abstraction.
+//!
+//! This module provides a flexible email sending capability that can be swapped
+//! between different providers (Mailtrap for dev, SendGrid/Postmark for production).
 
-/// Email service for sending emails
-/// Currently logs emails to console
-/// TODO: Integrate with SMTP or email service provider
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/// Represents an email address with optional display name
+#[derive(Debug, Clone, Serialize)]
+pub struct EmailAddress {
+    pub email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl EmailAddress {
+    pub fn new(email: impl Into<String>) -> Self {
+        Self {
+            email: email.into(),
+            name: None,
+        }
+    }
+
+    pub fn with_name(email: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            email: email.into(),
+            name: Some(name.into()),
+        }
+    }
+}
+
+/// Email body content - can be plain text, HTML, or both
+#[derive(Debug, Clone)]
+pub enum EmailBody {
+    Text(String),
+    Html(String),
+    Both { text: String, html: String },
+}
+
+/// Represents an email to be sent
+#[derive(Debug, Clone)]
+pub struct Email {
+    pub from: EmailAddress,
+    pub to: Vec<EmailAddress>,
+    pub subject: String,
+    pub body: EmailBody,
+}
+
+impl Email {
+    /// Create a new email builder
+    pub fn builder() -> EmailBuilder {
+        EmailBuilder::default()
+    }
+}
+
+/// Builder for constructing Email instances
+#[derive(Default)]
+pub struct EmailBuilder {
+    from: Option<EmailAddress>,
+    to: Vec<EmailAddress>,
+    subject: Option<String>,
+    body: Option<EmailBody>,
+}
+
+impl EmailBuilder {
+    pub fn from(mut self, address: EmailAddress) -> Self {
+        self.from = Some(address);
+        self
+    }
+
+    pub fn to(mut self, address: EmailAddress) -> Self {
+        self.to.push(address);
+        self
+    }
+
+    pub fn subject(mut self, subject: impl Into<String>) -> Self {
+        self.subject = Some(subject.into());
+        self
+    }
+
+    pub fn text_body(mut self, text: impl Into<String>) -> Self {
+        self.body = Some(EmailBody::Text(text.into()));
+        self
+    }
+
+    pub fn html_body(mut self, html: impl Into<String>) -> Self {
+        self.body = Some(EmailBody::Html(html.into()));
+        self
+    }
+
+    pub fn body(mut self, text: impl Into<String>, html: impl Into<String>) -> Self {
+        self.body = Some(EmailBody::Both {
+            text: text.into(),
+            html: html.into(),
+        });
+        self
+    }
+
+    pub fn build(self) -> Result<Email, SendError> {
+        let from = self
+            .from
+            .ok_or_else(|| SendError::Validation("Missing 'from' address".into()))?;
+
+        if self.to.is_empty() {
+            return Err(SendError::Validation("Missing 'to' address".into()));
+        }
+
+        let subject = self
+            .subject
+            .ok_or_else(|| SendError::Validation("Missing subject".into()))?;
+
+        let body = self
+            .body
+            .ok_or_else(|| SendError::Validation("Missing email body".into()))?;
+
+        Ok(Email {
+            from,
+            to: self.to,
+            subject,
+            body,
+        })
+    }
+}
+
+/// Response from a successful email send operation
+#[derive(Debug, Clone)]
+pub struct SendResponse {
+    /// Provider-specific message ID for tracking
+    pub message_id: Option<String>,
+    /// Human-readable status message
+    pub message: String,
+}
+
+/// Errors that can occur during email sending
+#[derive(Debug, thiserror::Error)]
+pub enum SendError {
+    #[error("Network error: {0}")]
+    Network(String),
+
+    #[error("Authentication failed: {0}")]
+    Authentication(String),
+
+    #[error("Validation error: {0}")]
+    Validation(String),
+
+    #[error("Rate limited: {0}")]
+    RateLimited(String),
+
+    #[error("Provider error: {0}")]
+    Provider(String),
+}
+
+// ============================================================================
+// EmailSender Trait
+// ============================================================================
+
+/// Trait for sending emails through various providers
+#[async_trait]
+pub trait EmailSender: Send + Sync {
+    /// Send an email through the provider
+    async fn send(&self, email: &Email) -> Result<SendResponse, SendError>;
+
+    /// Check if the sender is properly configured and ready to send
+    fn is_configured(&self) -> bool;
+}
+
+// ============================================================================
+// Mailtrap Implementation
+// ============================================================================
+
+/// Mailtrap HTTP API email sender
+///
+/// Uses Mailtrap's Send API for transactional emails.
+/// In sandbox mode, emails are captured for inspection rather than delivered.
+pub struct MailtrapSender {
+    client: reqwest::Client,
+    api_token: String,
+    base_url: String,
+}
+
+impl MailtrapSender {
+    const DEFAULT_BASE_URL: &'static str = "https://send.api.mailtrap.io";
+
+    pub fn new(api_token: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_token: api_token.into(),
+            base_url: Self::DEFAULT_BASE_URL.to_string(),
+        }
+    }
+
+    /// Create with custom base URL (useful for testing)
+    pub fn with_base_url(api_token: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_token: api_token.into(),
+            base_url: base_url.into(),
+        }
+    }
+}
+
+/// Mailtrap API request payload
+#[derive(Serialize)]
+struct MailtrapRequest {
+    from: MailtrapAddress,
+    to: Vec<MailtrapAddress>,
+    subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    html: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MailtrapAddress {
+    email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+impl From<&EmailAddress> for MailtrapAddress {
+    fn from(addr: &EmailAddress) -> Self {
+        Self {
+            email: addr.email.clone(),
+            name: addr.name.clone(),
+        }
+    }
+}
+
+/// Mailtrap API success response
+#[derive(Deserialize)]
+struct MailtrapResponse {
+    success: bool,
+    message_ids: Option<Vec<String>>,
+}
+
+/// Mailtrap API error response
+#[derive(Deserialize)]
+struct MailtrapErrorResponse {
+    errors: Option<Vec<String>>,
+    error: Option<String>,
+}
+
+#[async_trait]
+impl EmailSender for MailtrapSender {
+    async fn send(&self, email: &Email) -> Result<SendResponse, SendError> {
+        let (text, html) = match &email.body {
+            EmailBody::Text(t) => (Some(t.clone()), None),
+            EmailBody::Html(h) => (None, Some(h.clone())),
+            EmailBody::Both { text, html } => (Some(text.clone()), Some(html.clone())),
+        };
+
+        let request = MailtrapRequest {
+            from: MailtrapAddress::from(&email.from),
+            to: email.to.iter().map(MailtrapAddress::from).collect(),
+            subject: email.subject.clone(),
+            text,
+            html,
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/api/send", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_token))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| SendError::Network(e.to_string()))?;
+
+        let status = response.status();
+
+        if status.is_success() {
+            let body: MailtrapResponse = response
+                .json()
+                .await
+                .map_err(|e| SendError::Provider(format!("Failed to parse response: {}", e)))?;
+
+            if body.success {
+                Ok(SendResponse {
+                    message_id: body.message_ids.and_then(|ids| ids.into_iter().next()),
+                    message: "Email sent successfully".to_string(),
+                })
+            } else {
+                Err(SendError::Provider("Send reported failure".to_string()))
+            }
+        } else {
+            let error_body: MailtrapErrorResponse = response
+                .json()
+                .await
+                .unwrap_or(MailtrapErrorResponse {
+                    errors: None,
+                    error: Some("Unknown error".to_string()),
+                });
+
+            let error_msg = error_body
+                .errors
+                .map(|e| e.join(", "))
+                .or(error_body.error)
+                .unwrap_or_else(|| "Unknown error".to_string());
+
+            match status.as_u16() {
+                401 => Err(SendError::Authentication(error_msg)),
+                422 => Err(SendError::Validation(error_msg)),
+                429 => Err(SendError::RateLimited(error_msg)),
+                _ => Err(SendError::Provider(format!(
+                    "HTTP {}: {}",
+                    status.as_u16(),
+                    error_msg
+                ))),
+            }
+        }
+    }
+
+    fn is_configured(&self) -> bool {
+        !self.api_token.is_empty()
+    }
+}
+
+// ============================================================================
+// Logging Implementation (Fallback)
+// ============================================================================
+
+/// A fallback email sender that logs emails instead of sending them.
+/// Useful for development when email credentials aren't configured.
+pub struct LoggingEmailSender;
+
+impl LoggingEmailSender {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LoggingEmailSender {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl EmailSender for LoggingEmailSender {
+    async fn send(&self, email: &Email) -> Result<SendResponse, SendError> {
+        let (text, html) = match &email.body {
+            EmailBody::Text(t) => (t.clone(), String::new()),
+            EmailBody::Html(h) => (String::new(), h.clone()),
+            EmailBody::Both { text, html } => (text.clone(), html.clone()),
+        };
+
+        let from_display = email
+            .from
+            .name
+            .as_ref()
+            .map(|n| format!("{} <{}>", n, email.from.email))
+            .unwrap_or_else(|| email.from.email.clone());
+
+        let to_display: Vec<String> = email
+            .to
+            .iter()
+            .map(|addr| {
+                addr.name
+                    .as_ref()
+                    .map(|n| format!("{} <{}>", n, addr.email))
+                    .unwrap_or_else(|| addr.email.clone())
+            })
+            .collect();
+
+        info!(
+            "\n=== EMAIL (NOT SENT - LOGGING ONLY) ===\n\
+            From: {}\n\
+            To: {}\n\
+            Subject: {}\n\
+            ---\n\
+            Text Body:\n{}\n\
+            ---\n\
+            HTML Body:\n{}\n\
+            =======================================",
+            from_display,
+            to_display.join(", "),
+            email.subject,
+            text,
+            html
+        );
+
+        Ok(SendResponse {
+            message_id: None,
+            message: "Email logged (not sent - no email provider configured)".to_string(),
+        })
+    }
+
+    fn is_configured(&self) -> bool {
+        false
+    }
+}
+
+// ============================================================================
+// Email Service Configuration
+// ============================================================================
+
+/// Configuration for the email service
 #[derive(Clone, Debug)]
+pub struct EmailConfig {
+    pub mailtrap_api_token: Option<String>,
+    pub sender_email: String,
+    pub sender_name: String,
+}
+
+impl EmailConfig {
+    /// Check if Mailtrap is configured with valid credentials
+    pub fn has_mailtrap(&self) -> bool {
+        self.mailtrap_api_token
+            .as_ref()
+            .is_some_and(|t| !t.is_empty())
+    }
+}
+
+impl Default for EmailConfig {
+    fn default() -> Self {
+        Self {
+            mailtrap_api_token: None,
+            sender_email: "noreply@example.com".to_string(),
+            sender_name: "CrustyRustacean Dev Blog".to_string(),
+        }
+    }
+}
+
+// ============================================================================
+// Email Service (High-Level API)
+// ============================================================================
+
+/// High-level email service that wraps the provider-specific sender
+/// and provides convenient methods for common email types.
+#[derive(Clone)]
 pub struct EmailService {
+    sender: Arc<dyn EmailSender>,
     pub from_email: String,
     pub from_name: String,
 }
 
 impl EmailService {
-    pub fn new(from_email: String, from_name: String) -> Self {
+    /// Create a new email service with the given sender
+    pub fn new(sender: Arc<dyn EmailSender>, from_email: String, from_name: String) -> Self {
         Self {
+            sender,
             from_email,
             from_name,
         }
     }
 
-    /// Send password reset email
-    /// Currently logs to console
-    /// TODO: Integrate actual email sending
+    /// Create an email service from configuration.
+    /// Returns a Mailtrap sender if configured, otherwise a logging sender.
+    pub fn from_config(config: &EmailConfig) -> Self {
+        let sender: Arc<dyn EmailSender> = if config.has_mailtrap() {
+            info!("Email service configured with Mailtrap");
+            Arc::new(MailtrapSender::new(
+                config.mailtrap_api_token.as_ref().unwrap(),
+            ))
+        } else {
+            warn!("No email provider configured - emails will be logged only");
+            Arc::new(LoggingEmailSender::new())
+        };
+
+        Self {
+            sender,
+            from_email: config.sender_email.clone(),
+            from_name: config.sender_name.clone(),
+        }
+    }
+
+    /// Check if the service has a real email provider configured
+    pub fn is_configured(&self) -> bool {
+        self.sender.is_configured()
+    }
+
+    /// Get the configured sender address
+    fn sender_address(&self) -> EmailAddress {
+        EmailAddress::with_name(&self.from_email, &self.from_name)
+    }
+
+    /// Send a password reset email
     pub async fn send_password_reset_email(
         &self,
         to_email: &str,
         username: &str,
         reset_token: &str,
         base_url: &str,
-    ) -> Result<(), ApiError> {
+    ) -> Result<SendResponse, SendError> {
         let reset_link = format!("{}/password-reset/{}", base_url, reset_token);
 
-        // For now, just log the email content
-        // In production, this would send an actual email
-        info!(
-            "=== PASSWORD RESET EMAIL ===\n\
-            To: {}\n\
-            From: {} <{}>\n\
-            Subject: Reset Your Password - CrustyRustacean Dev Blog\n\n\
-            Hi {},\n\n\
+        let text_body = format!(
+            "Hi {},\n\n\
             You requested to reset your password for your CrustyRustacean Dev Blog account.\n\n\
             Click the link below to reset your password:\n\
             {}\n\n\
             This link will expire in 1 hour.\n\n\
             If you didn't request this password reset, please ignore this email.\n\n\
             Best regards,\n\
-            CrustyRustacean Dev Blog Team\n\
-            ===========================",
-            to_email, self.from_name, self.from_email, username, reset_link
+            CrustyRustacean Dev Blog Team",
+            username, reset_link
         );
 
-        Ok(())
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Reset Your Password</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #2c3e50;">Reset Your Password</h2>
+        <p>Hi {},</p>
+        <p>You requested to reset your password for your CrustyRustacean Dev Blog account.</p>
+        <p>
+            <a href="{}" style="display: inline-block; padding: 12px 24px; background-color: #3498db; color: white; text-decoration: none; border-radius: 4px;">
+                Reset Password
+            </a>
+        </p>
+        <p>Or copy and paste this link into your browser:</p>
+        <p style="word-break: break-all; color: #7f8c8d;">{}</p>
+        <p><strong>This link will expire in 1 hour.</strong></p>
+        <p>If you didn't request this password reset, please ignore this email.</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
+        <p style="color: #7f8c8d; font-size: 12px;">
+            Best regards,<br>
+            CrustyRustacean Dev Blog Team
+        </p>
+    </div>
+</body>
+</html>"#,
+            username, reset_link, reset_link
+        );
+
+        let email = Email::builder()
+            .from(self.sender_address())
+            .to(EmailAddress::new(to_email))
+            .subject("Reset Your Password - CrustyRustacean Dev Blog")
+            .body(text_body, html_body)
+            .build()?;
+
+        self.sender.send(&email).await
     }
 
-    /// Send welcome email
-    /// Currently logs to console
-    /// TODO: Integrate actual email sending
-    pub async fn send_welcome_email(&self, to_email: &str, username: &str) -> Result<(), ApiError> {
-        info!(
-            "=== WELCOME EMAIL ===\n\
-            To: {}\n\
-            From: {} <{}>\n\
-            Subject: Welcome to CrustyRustacean Dev Blog!\n\n\
-            Hi {},\n\n\
+    /// Send a welcome email to a newly registered user
+    pub async fn send_welcome_email(
+        &self,
+        to_email: &str,
+        username: &str,
+    ) -> Result<SendResponse, SendError> {
+        let text_body = format!(
+            "Hi {},\n\n\
             Welcome to CrustyRustacean Dev Blog! Your account has been created successfully.\n\n\
             You can now:\n\
-            - Write and publish articles\n\
-            - Follow other authors\n\
-            - Comment on articles\n\
-            - Save your favorites\n\n\
-            Get started by visiting our website and logging in with your credentials.\n\n\
+            - Read and comment on articles\n\
+            - Follow your favorite authors\n\
+            - Save articles to your favorites\n\n\
+            Get started by visiting our website and exploring the content.\n\n\
             Best regards,\n\
-            CrustyRustacean Dev Blog Team\n\
-            =====================",
-            to_email, self.from_name, self.from_email, username
+            CrustyRustacean Dev Blog Team",
+            username
         );
 
-        Ok(())
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Welcome to CrustyRustacean Dev Blog</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #2c3e50;">Welcome to CrustyRustacean Dev Blog!</h2>
+        <p>Hi {},</p>
+        <p>Your account has been created successfully.</p>
+        <p>You can now:</p>
+        <ul>
+            <li>Read and comment on articles</li>
+            <li>Follow your favorite authors</li>
+            <li>Save articles to your favorites</li>
+        </ul>
+        <p>Get started by visiting our website and exploring the content.</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
+        <p style="color: #7f8c8d; font-size: 12px;">
+            Best regards,<br>
+            CrustyRustacean Dev Blog Team
+        </p>
+    </div>
+</body>
+</html>"#,
+            username
+        );
+
+        let email = Email::builder()
+            .from(self.sender_address())
+            .to(EmailAddress::new(to_email))
+            .subject("Welcome to CrustyRustacean Dev Blog!")
+            .body(text_body, html_body)
+            .build()?;
+
+        self.sender.send(&email).await
+    }
+
+    /// Send a generic email
+    pub async fn send(&self, email: &Email) -> Result<SendResponse, SendError> {
+        self.sender.send(email).await
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Mock email sender for testing
+    struct MockEmailSender {
+        sent_emails: Mutex<Vec<Email>>,
+        should_fail: bool,
+    }
+
+    impl MockEmailSender {
+        fn new() -> Self {
+            Self {
+                sent_emails: Mutex::new(Vec::new()),
+                should_fail: false,
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                sent_emails: Mutex::new(Vec::new()),
+                should_fail: true,
+            }
+        }
+
+        fn get_sent_emails(&self) -> Vec<Email> {
+            self.sent_emails.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl EmailSender for MockEmailSender {
+        async fn send(&self, email: &Email) -> Result<SendResponse, SendError> {
+            if self.should_fail {
+                return Err(SendError::Provider("Mock failure".to_string()));
+            }
+            self.sent_emails.lock().unwrap().push(email.clone());
+            Ok(SendResponse {
+                message_id: Some("mock-id-123".to_string()),
+                message: "Mock email sent".to_string(),
+            })
+        }
+
+        fn is_configured(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn test_email_builder_success() {
+        let email = Email::builder()
+            .from(EmailAddress::with_name("sender@example.com", "Sender"))
+            .to(EmailAddress::new("recipient@example.com"))
+            .subject("Test Subject")
+            .text_body("Hello, world!")
+            .build();
+
+        assert!(email.is_ok());
+        let email = email.unwrap();
+        assert_eq!(email.from.email, "sender@example.com");
+        assert_eq!(email.to.len(), 1);
+        assert_eq!(email.subject, "Test Subject");
+    }
+
+    #[test]
+    fn test_email_builder_missing_from() {
+        let result = Email::builder()
+            .to(EmailAddress::new("recipient@example.com"))
+            .subject("Test")
+            .text_body("Body")
+            .build();
+
+        assert!(matches!(result, Err(SendError::Validation(_))));
+    }
+
+    #[test]
+    fn test_email_builder_missing_to() {
+        let result = Email::builder()
+            .from(EmailAddress::new("sender@example.com"))
+            .subject("Test")
+            .text_body("Body")
+            .build();
+
+        assert!(matches!(result, Err(SendError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_mock_sender_success() {
+        let sender = MockEmailSender::new();
+        let email = Email::builder()
+            .from(EmailAddress::new("test@example.com"))
+            .to(EmailAddress::new("recipient@example.com"))
+            .subject("Test")
+            .text_body("Body")
+            .build()
+            .unwrap();
+
+        let result = sender.send(&email).await;
+        assert!(result.is_ok());
+
+        let sent = sender.get_sent_emails();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].subject, "Test");
+    }
+
+    #[tokio::test]
+    async fn test_mock_sender_failure() {
+        let sender = MockEmailSender::failing();
+        let email = Email::builder()
+            .from(EmailAddress::new("test@example.com"))
+            .to(EmailAddress::new("recipient@example.com"))
+            .subject("Test")
+            .text_body("Body")
+            .build()
+            .unwrap();
+
+        let result = sender.send(&email).await;
+        assert!(matches!(result, Err(SendError::Provider(_))));
+    }
+
+    #[tokio::test]
+    async fn test_email_service_welcome_email() {
+        let mock_sender = Arc::new(MockEmailSender::new());
+        let service = EmailService::new(
+            mock_sender.clone(),
+            "noreply@example.com".to_string(),
+            "Test App".to_string(),
+        );
+
+        let result = service
+            .send_welcome_email("user@example.com", "testuser")
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_email_service_password_reset() {
+        let mock_sender = Arc::new(MockEmailSender::new());
+        let service = EmailService::new(
+            mock_sender.clone(),
+            "noreply@example.com".to_string(),
+            "Test App".to_string(),
+        );
+
+        let result = service
+            .send_password_reset_email(
+                "user@example.com",
+                "testuser",
+                "reset-token-123",
+                "https://example.com",
+            )
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_email_config_has_mailtrap() {
+        let config_with_token = EmailConfig {
+            mailtrap_api_token: Some("valid-token".to_string()),
+            ..Default::default()
+        };
+        assert!(config_with_token.has_mailtrap());
+
+        let config_empty_token = EmailConfig {
+            mailtrap_api_token: Some("".to_string()),
+            ..Default::default()
+        };
+        assert!(!config_empty_token.has_mailtrap());
+
+        let config_no_token = EmailConfig::default();
+        assert!(!config_no_token.has_mailtrap());
+    }
+
+    #[test]
+    fn test_logging_sender_is_not_configured() {
+        let sender = LoggingEmailSender::new();
+        assert!(!sender.is_configured());
     }
 }

--- a/src/lib/routes/users.rs
+++ b/src/lib/routes/users.rs
@@ -95,6 +95,19 @@ pub async fn register_user(
     )
     .await?;
 
+    // Send welcome email (fire and forget - don't block registration on email delivery)
+    let email_service = state.email.clone();
+    let email_addr = user_data.email.clone();
+    let username_for_email = user_data.username.clone();
+    tokio::spawn(async move {
+        if let Err(e) = email_service
+            .send_welcome_email(&email_addr, &username_for_email)
+            .await
+        {
+            tracing::warn!("Failed to send welcome email to {}: {}", email_addr, e);
+        }
+    });
+
     let token = generate_token(user_id, &state.jwt_keys)?;
 
     let response = UserResponse {

--- a/src/lib/state.rs
+++ b/src/lib/state.rs
@@ -2,6 +2,7 @@
 
 // dependencies
 use crate::auth::Keys;
+use crate::email::EmailService;
 use crate::storage::StorageBackend;
 use crate::{ApiError, AppConfig, DatabaseConnection};
 use once_cell::sync::OnceCell;
@@ -31,6 +32,7 @@ pub struct AppState {
     pub jwt_keys: Keys,
     pub storage: Arc<dyn StorageBackend>,
     pub cached_tags: TagCache,
+    pub email: EmailService,
 }
 
 // simplified setup function
@@ -99,6 +101,7 @@ impl AppState {
     ) -> Result<Self, ApiError> {
         let templates = setup_templates(config)?;
         let jwt_keys = Keys::from_config(config);
+        let email = EmailService::from_config(&config.email);
 
         Ok(Self {
             templates,
@@ -106,6 +109,7 @@ impl AppState {
             jwt_keys,
             storage,
             cached_tags: Arc::new(RwLock::new(None)),
+            email,
         })
     }
 }
@@ -113,6 +117,7 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::email::EmailConfig;
     use std::fs;
     use tempfile::TempDir;
 
@@ -124,6 +129,7 @@ mod tests {
             override_stylesheet: "/static/overrides.css".to_string(),
             app_version: "2.9.0".to_string(),
             allowed_origins: vec!["http://localhost:8000".to_string()],
+            email: EmailConfig::default(),
         }
     }
 
@@ -164,6 +170,7 @@ mod tests {
             override_stylesheet: "".to_string(),
             app_version: "2.9.0".to_string(),
             allowed_origins: vec!["http://localhost:8000".to_string()],
+            email: EmailConfig::default(),
         };
         let _temp_dir = setup_test_templates_dir();
 
@@ -184,6 +191,7 @@ mod tests {
             override_stylesheet: "/static/override-theme.css".to_string(),
             app_version: "2.9.0".to_string(),
             allowed_origins: vec!["http://localhost:8000".to_string()],
+            email: EmailConfig::default(),
         };
         let _temp_dir = setup_test_templates_dir();
 


### PR DESCRIPTION
Implement a flexible email sending system using Rust traits for provider abstraction:

- Add EmailSender trait with send() and is_configured() methods
- Implement MailtrapSender for Mailtrap HTTP API integration
- Add LoggingEmailSender as fallback when no provider configured
- Create Email, EmailAddress, SendResponse, and SendError types
- Add EmailBuilder for fluent email construction
- Integrate email service into AppConfig and AppState
- Wire welcome email sending into user registration flow
- Send emails asynchronously (fire-and-forget) to not block registration
- Add comprehensive unit tests for email module
- Create Secrets.dev.toml template for local development

The design allows swapping email providers (Mailtrap, SendGrid, etc.) without code changes - just update configuration.