### PR TITLE
feat: Require email verification for registration

### DIFF
--- a/src/lib/errors.rs
+++ b/src/lib/errors.rs
@@ -29,6 +29,9 @@ pub enum ApiError {
     #[error("Internal server error: {0}")]
     InternalServerError(String),
 
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     // Template-specific errors
     #[error(transparent)]
     Tera(#[from] tera::Error),
@@ -99,7 +102,22 @@ impl From<chrono::ParseError> for ApiError {
 impl From<crate::email::SendError> for ApiError {
     fn from(err: crate::email::SendError) -> Self {
         tracing::error!("Email sending error: {}", err);
-        ApiError::InternalServerError("Failed to send email".to_string())
+
+        // Provide user-friendly messages based on error type
+        let message = match &err {
+            crate::email::SendError::Network(_) => {
+                "Unable to send verification email. Please try again later.".to_string()
+            }
+            crate::email::SendError::RateLimited => {
+                "Too many requests. Please wait a moment and try again.".to_string()
+            }
+            crate::email::SendError::Authentication(_) => {
+                "Email service configuration error. Please contact support.".to_string()
+            }
+            _ => "Unable to send verification email. Please try again later.".to_string(),
+        };
+
+        ApiError::ServiceUnavailable(message)
     }
 }
 
@@ -114,6 +132,7 @@ impl IntoResponse for ApiError {
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg),
             ApiError::UnprocessableEntity(msg) => (StatusCode::UNPROCESSABLE_ENTITY, msg),
             ApiError::InternalServerError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
             ApiError::Tera(err) => {
                 // Log the actual template error for debugging
                 tracing::error!("Template rendering error: {}", err);

--- a/src/lib/routes/users.rs
+++ b/src/lib/routes/users.rs
@@ -118,8 +118,8 @@ pub async fn register_user(
     };
     let base_url = format!("{}://{}", protocol, host);
 
-    // Fire-and-forget: registration succeeds even if email fails
-    if let Err(e) = state
+    // Send verification email - registration fails if email cannot be sent
+    state
         .email
         .send_email_verification(
             &user_data.email,
@@ -127,10 +127,7 @@ pub async fn register_user(
             &verification_token,
             &base_url,
         )
-        .await
-    {
-        tracing::warn!("Failed to send verification email to {}: {}", user_data.email, e);
-    }
+        .await?;
 
     let response = RegistrationSuccessResponse {
         message: "Registration successful! Please check your email to verify your account."

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -81,6 +81,10 @@ fn load_test_secret_store() -> Result<SecretStore> {
         let s = v
             .as_str()
             .ok_or_else(|| anyhow!("Secret {k} must be a string in {}", path))?;
+        // Skip Mailtrap API token in tests - we want to use LoggingEmailSender
+        if k == "MAILTRAP_API_TOKEN" {
+            continue;
+        }
         map.insert(k.clone(), Secret::new(s.to_owned()));
     }
 


### PR DESCRIPTION
- Registration now fails with 503 if email cannot be sent
- Added ServiceUnavailable error variant for email failures
- User-friendly error messages based on failure type:
  - Network errors: "Please try again later"
  - Rate limited: "Wait a moment and try again"
  - Auth errors: "Contact support"
- Tests skip Mailtrap token to use LoggingEmailSender
- Login already checks email_verified before allowing access