### PR TITLE
fix: Update auth.js to handle ApiResponse wrapper format

### DIFF
--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -137,7 +137,8 @@ class AuthManager {
                 if (response.ok) {
                     const data = await response.json();
                     // Registration successful - redirect to login with verification message
-                    const email = encodeURIComponent(data.email);
+                    // Response is wrapped in ApiResponse: { success, data: { email, message } }
+                    const email = encodeURIComponent(data.data?.email || data.email || '');
                     window.location.href = `/login?registered=true&email=${email}`;
                 } else {
                     const errorData = await response.json();


### PR DESCRIPTION
Frontend now correctly extracts email from data.data.email for the new ApiResponse format while maintaining backwards compatibility with data.email fallback.