### PR TITLE
fix: correct sitemap lastmod date format for W3C compliance

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -18,6 +18,7 @@ pub mod shortcodes;
 pub mod state;
 pub mod storage;
 pub mod telemetry;
+pub mod xml;
 
 // re-exports for easier access
 pub use auth::*;
@@ -33,3 +34,4 @@ pub use shortcodes::*;
 pub use state::*;
 pub use storage::*;
 pub use telemetry::*;
+pub use xml::*;

--- a/src/lib/routes/rss.rs
+++ b/src/lib/routes/rss.rs
@@ -1,6 +1,6 @@
 // src/lib/routes/rss.rs
 
-use crate::{ApiError, AppState};
+use crate::{ApiError, AppState, escape_xml};
 use axum::{
     extract::State,
     http::{StatusCode, header},
@@ -106,29 +106,4 @@ pub async fn get_rss_feed(State(state): State<AppState>) -> Result<Response, Api
         rss_feed,
     )
         .into_response())
-}
-
-// Helper function to escape XML special characters
-fn escape_xml(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_escape_xml() {
-        assert_eq!(escape_xml("Hello & goodbye"), "Hello &amp; goodbye");
-        assert_eq!(escape_xml("<tag>"), "&lt;tag&gt;");
-        assert_eq!(
-            escape_xml("It's \"quoted\" & <escaped>"),
-            "It&apos;s &quot;quoted&quot; &amp; &lt;escaped&gt;"
-        );
-    }
 }

--- a/src/lib/routes/sitemap.rs
+++ b/src/lib/routes/sitemap.rs
@@ -1,6 +1,6 @@
 // src/lib/routes/sitemap.rs
 
-use crate::{ApiError, AppState};
+use crate::{ApiError, AppState, escape_xml};
 use axum::{
     extract::State,
     http::{StatusCode, header},
@@ -73,8 +73,8 @@ pub async fn get_sitemap(State(state): State<AppState>) -> Result<Response, ApiE
             .map_err(|e| ApiError::InternalServerError(format!("Invalid timestamp: {}", e)))?
             .with_timezone(&Utc);
 
-        // Format as W3C Datetime (ISO 8601)
-        let lastmod = updated_at.format("%Y-%m-%dT%H:%M:%S%z").to_string();
+        // Format as W3C Datetime (ISO 8601) - use to_rfc3339() for correct timezone format
+        let lastmod = updated_at.to_rfc3339();
 
         // Escape the slug for XML
         let slug_escaped = escape_xml(&slug);
@@ -109,29 +109,4 @@ pub async fn get_sitemap(State(state): State<AppState>) -> Result<Response, ApiE
         sitemap,
     )
         .into_response())
-}
-
-// Helper function to escape XML special characters
-fn escape_xml(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_escape_xml() {
-        assert_eq!(escape_xml("Hello & goodbye"), "Hello &amp; goodbye");
-        assert_eq!(escape_xml("<tag>"), "&lt;tag&gt;");
-        assert_eq!(
-            escape_xml("It's \"quoted\" & <escaped>"),
-            "It&apos;s &quot;quoted&quot; &amp; &lt;escaped&gt;"
-        );
-    }
 }

--- a/src/lib/xml.rs
+++ b/src/lib/xml.rs
@@ -1,0 +1,56 @@
+// src/lib/xml.rs
+
+/// Escape XML special characters in a string.
+///
+/// Replaces the following characters with their XML entity equivalents:
+/// - `&` → `&amp;`
+/// - `<` → `&lt;`
+/// - `>` → `&gt;`
+/// - `"` → `&quot;`
+/// - `'` → `&apos;`
+pub fn escape_xml(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_xml_ampersand() {
+        assert_eq!(escape_xml("Hello & goodbye"), "Hello &amp; goodbye");
+    }
+
+    #[test]
+    fn test_escape_xml_angle_brackets() {
+        assert_eq!(escape_xml("<tag>"), "&lt;tag&gt;");
+    }
+
+    #[test]
+    fn test_escape_xml_quotes() {
+        assert_eq!(escape_xml(r#"It's "quoted""#), "It&apos;s &quot;quoted&quot;");
+    }
+
+    #[test]
+    fn test_escape_xml_all_special_chars() {
+        assert_eq!(
+            escape_xml("It's \"quoted\" & <escaped>"),
+            "It&apos;s &quot;quoted&quot; &amp; &lt;escaped&gt;"
+        );
+    }
+
+    #[test]
+    fn test_escape_xml_no_special_chars() {
+        assert_eq!(escape_xml("Hello World"), "Hello World");
+    }
+
+    #[test]
+    fn test_escape_xml_empty_string() {
+        assert_eq!(escape_xml(""), "");
+    }
+}


### PR DESCRIPTION
The sitemap was using chrono's %z format which outputs timezone offsets without a colon (+0000), but Google Search Console requires W3C Datetime format with a colon (+00:00). Changed to use to_rfc3339() which produces the correct format.

Also consolidated duplicate escape_xml functions from sitemap.rs and rss.rs into a shared xml.rs module to improve code maintainability.