### PR TITLE
fix: improve SEO with canonical URLs, meta tags, and structured data

### DIFF
--- a/src/lib/routes/sitemap.rs
+++ b/src/lib/routes/sitemap.rs
@@ -14,12 +14,13 @@ pub async fn get_sitemap(State(state): State<AppState>) -> Result<Response, ApiE
         .connect()
         .map_err(ApiError::from_connection_error)?;
 
-    // Get all articles with their update times
+    // Get all published articles with their update times (exclude drafts)
     let mut article_rows = conn
         .query(
             r#"
             SELECT slug, updated_at
             FROM articles
+            WHERE draft = 0
             ORDER BY updated_at DESC
             "#,
             libsql::params![],

--- a/templates/about.html
+++ b/templates/about.html
@@ -2,6 +2,14 @@
 
 {% block title %}About - CrustyRustacean Dev Blog{% endblock %}
 
+{% block meta_description %}
+<meta name="description" content="Learn about CrustyRustacean - a hobbyist developer sharing insights and tutorials about Rust programming and software engineering.">
+{% endblock %}
+
+{% block canonical %}
+<link rel="canonical" href="https://crusty-rustacean.com/about">
+{% endblock %}
+
 {% block content %}
 <!-- Hero Image Section -->
 <div class="row mb-4">

--- a/templates/articles/article.html
+++ b/templates/articles/article.html
@@ -2,6 +2,14 @@
 
 {% block title %}{{ article.title }} - CrustyRustacean Dev Blog{% endblock %}
 
+{% block meta_description %}
+<meta name="description" content="{{ article.description | truncate(length=160) }}">
+{% endblock %}
+
+{% block canonical %}
+<link rel="canonical" href="https://crusty-rustacean.com/articles/{{ article.slug }}">
+{% endblock %}
+
 {% block content %}
 <div class="container">
     <div class="row">
@@ -190,6 +198,36 @@
     </div>
 </div>
 {% endif %}
+
+<!-- JSON-LD Structured Data for SEO -->
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "{{ article.title | escape }}",
+    "description": "{{ article.description | escape }}",
+    "author": {
+        "@type": "Person",
+        "name": "{{ article.author.username | escape }}"{% if article.author.image %},
+        "image": "{{ article.author.image }}"{% endif %}
+    },
+    "publisher": {
+        "@type": "Organization",
+        "name": "CrustyRustacean Dev Blog",
+        "logo": {
+            "@type": "ImageObject",
+            "url": "https://crusty-rustacean.com/static/favicon.png"
+        }
+    },
+    "datePublished": "{{ article.createdAt | date(format="%Y-%m-%dT%H:%M:%SZ") }}",
+    "dateModified": "{{ article.updatedAt | date(format="%Y-%m-%dT%H:%M:%SZ") }}",
+    "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://crusty-rustacean.com/articles/{{ article.slug }}"
+    }{% if article.tagList and article.tagList | length > 0 %},
+    "keywords": "{{ article.tagList | join(sep=", ") }}"{% endif %}
+}
+</script>
 {% endblock %}
 
 {% block scripts %}

--- a/templates/articles/list.html
+++ b/templates/articles/list.html
@@ -1,6 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}All Articles - CrustyRustacean Dev Blog{% endblock %}
+{% block title %}All Articles{% if pagination and pagination.current_page > 1 %} - Page {{ pagination.current_page }}{% endif %} - CrustyRustacean Dev Blog{% endblock %}
+
+{% block meta_description %}
+<meta name="description" content="Browse all articles on CrustyRustacean Dev Blog. Explore tutorials, guides, and insights about Rust programming and software development.">
+{% endblock %}
+
+{% block canonical %}
+<link rel="canonical" href="https://crusty-rustacean.com/articles">
+{% endblock %}
+
+{% block robots %}
+{% if pagination and pagination.current_page > 1 %}
+<meta name="robots" content="noindex, follow">
+{% endif %}
+{% endblock %}
 
 {% block content %}
 <!-- Hero Image Section -->

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,9 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{% block title %}Crusty Rustacean{% endblock %}</title>
+        {% block meta_description %}{% endblock %}
+        {% block canonical %}{% endblock %}
+        {% block robots %}{% endblock %}
         <!-- Google tag (gtag.js) -->
         <script
             async

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,14 @@
 
 {% block title %}{{ title }} - CrustyRustacean Dev Blog{% endblock %}
 
+{% block meta_description %}
+<meta name="description" content="CrustyRustacean Dev Blog - A hobbyist's journey learning and sharing insights about Rust programming, systems development, and software engineering.">
+{% endblock %}
+
+{% block canonical %}
+<link rel="canonical" href="https://crusty-rustacean.com/">
+{% endblock %}
+
 {% block content %}
 <!-- Hero Image Section -->
 <div class="row mb-4">

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -2,6 +2,14 @@
 
 {% block title %}Privacy Policy - CrustyRustacean Dev Blog{% endblock %}
 
+{% block meta_description %}
+<meta name="description" content="Privacy Policy for CrustyRustacean Dev Blog. Learn how we collect, use, and protect your personal information.">
+{% endblock %}
+
+{% block canonical %}
+<link rel="canonical" href="https://crusty-rustacean.com/privacy">
+{% endblock %}
+
 {% block content %}
 <!-- Hero Image Section -->
 <div class="row mb-4">

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -2,6 +2,14 @@
 
 {% block title %}Terms of Service - CrustyRustacean Dev Blog{% endblock %}
 
+{% block meta_description %}
+<meta name="description" content="Terms of Service for CrustyRustacean Dev Blog. Read our terms and conditions for using this website.">
+{% endblock %}
+
+{% block canonical %}
+<link rel="canonical" href="https://crusty-rustacean.com/terms">
+{% endblock %}
+
 {% block content %}
 <!-- Hero Image Section -->
 <div class="row mb-4">

--- a/tests/api/sitemap.rs
+++ b/tests/api/sitemap.rs
@@ -213,6 +213,79 @@ async fn sitemap_returns_valid_xml_when_no_articles() {
 }
 
 #[tokio::test]
+async fn sitemap_excludes_draft_articles() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Register a user
+    let token = app
+        .register_user("draftuser", "draft@example.com", "password123")
+        .await;
+
+    // Create a published article
+    let published_article = json!({
+        "article": {
+            "title": "Published Sitemap Article",
+            "description": "This should appear in the sitemap",
+            "body": "Published content",
+            "tagList": []
+        }
+    });
+
+    app.client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&published_article)
+        .send()
+        .await
+        .expect("Failed to create published article");
+
+    // Create a draft article
+    let draft_article = json!({
+        "article": {
+            "title": "Draft Sitemap Article",
+            "description": "This should NOT appear in the sitemap",
+            "body": "Draft content",
+            "tagList": [],
+            "draft": true
+        }
+    });
+
+    app.client
+        .post(format!("{}/api/articles", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&draft_article)
+        .send()
+        .await
+        .expect("Failed to create draft article");
+
+    // Act - Get sitemap
+    let response = app
+        .client
+        .get(format!("{}/sitemap.xml", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.text().await.expect("Failed to get response body");
+
+    // Published article should be in sitemap
+    assert!(
+        body.contains("published-sitemap-article"),
+        "Published article should appear in sitemap"
+    );
+
+    // Draft article should NOT be in sitemap
+    assert!(
+        !body.contains("draft-sitemap-article"),
+        "Draft article should NOT appear in sitemap"
+    );
+}
+
+#[tokio::test]
 async fn sitemap_articles_sorted_by_update_time() {
     // Arrange
     let app = spawn_app().await;


### PR DESCRIPTION
This commit addresses several Google Search Console indexing issues:

- Exclude draft articles from sitemap (fixes 404 errors for draft URLs)
- Add canonical URL tags to all public pages
- Add meta description tags for better search snippets
- Add robots noindex for paginated article list pages
- Add JSON-LD structured data for articles (BlogPosting schema)

Also adds new test to verify draft articles are excluded from sitemap.

Fixes issues:
- "Not found (404)" - drafts no longer in sitemap
- "Duplicate without user-selected canonical" - canonical tags added
- "Crawled - currently not indexed" - meta descriptions added