### PR TITLE
refactor: reduce test code bloat with improved helpers

### DIFF
--- a/tests/api/feed_page.rs
+++ b/tests/api/feed_page.rs
@@ -1,6 +1,6 @@
 // tests/api/feed_page.rs
 
-use crate::helpers::{TestUserBuilder, spawn_app};
+use crate::helpers::{assert_body_contains, HtmlResponseValidator, TestUserBuilder, spawn_app};
 use reqwest::StatusCode;
 
 #[tokio::test]
@@ -24,11 +24,7 @@ async fn test_feed_page_requires_authentication() {
 async fn test_feed_page_with_authentication() {
     // Arrange
     let app = spawn_app().await;
-
-    // Register user using helper
-    let token = app
-        .register_user("feeduser", "feeduser@example.com", "securepassword123")
-        .await;
+    let token = app.register_user_default("feeduser").await;
 
     // Act - Access feed page with authentication
     let response = app
@@ -42,18 +38,6 @@ async fn test_feed_page_with_authentication() {
     // Assert - Should return HTML page (200 OK)
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Check that it returns HTML content
-    let content_type = response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-
-    // Should be HTML, not JSON
-    assert!(content_type.contains("text/html") || content_type.is_empty());
-
-    // Check that the response body contains HTML
-    let body = response.text().await.expect("Failed to get response body");
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-    assert!(body.contains("Your Personal Feed")); // Should contain the feed title
+    let body = response.assert_html_response().await;
+    assert_body_contains(&body, &["Your Personal Feed"]);
 }

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -295,6 +295,21 @@ pub trait TestArticleBuilder {
         )
         .await
     }
+
+    /// Create a draft article and return its slug
+    async fn create_draft_article(
+        &self,
+        token: &str,
+        title: &str,
+        description: &str,
+        body: &str,
+    ) -> String;
+
+    /// Create a draft article with minimal parameters
+    async fn create_draft_article_simple(&self, token: &str, title: &str) -> String {
+        self.create_draft_article(token, title, "Draft description", "Draft body content")
+            .await
+    }
 }
 
 #[async_trait]
@@ -341,6 +356,100 @@ impl TestArticleBuilder for TestApp {
         body["article"]["slug"]
             .as_str()
             .expect("Slug not found in response")
+            .to_string()
+    }
+
+    async fn create_draft_article(
+        &self,
+        token: &str,
+        title: &str,
+        description: &str,
+        body: &str,
+    ) -> String {
+        let article_data = json!({
+            "article": {
+                "title": title,
+                "description": description,
+                "body": body,
+                "draft": true
+            }
+        });
+
+        let response = self
+            .client
+            .post(format!("{}/api/articles", &self.address))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&article_data)
+            .send()
+            .await
+            .expect("Failed to create draft article");
+
+        let status = response.status();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .expect("Failed to parse draft article response");
+
+        if !status.is_success() {
+            panic!(
+                "Draft article creation failed with status {}: {:?}",
+                status, body
+            );
+        }
+
+        body["article"]["slug"]
+            .as_str()
+            .expect("Slug not found in draft response")
+            .to_string()
+    }
+}
+
+/// Trait for adding comments to articles
+#[async_trait]
+pub trait TestCommentBuilder {
+    /// Add a comment to an article and return the comment ID as string
+    async fn add_comment(&self, token: &str, slug: &str, body: &str) -> String;
+
+    /// Add a simple comment with default text
+    async fn add_comment_simple(&self, token: &str, slug: &str) -> String {
+        self.add_comment(token, slug, "This is a test comment.")
+            .await
+    }
+}
+
+#[async_trait]
+impl TestCommentBuilder for TestApp {
+    async fn add_comment(&self, token: &str, slug: &str, comment_body: &str) -> String {
+        let comment_data = json!({
+            "comment": {
+                "body": comment_body
+            }
+        });
+
+        let response = self
+            .client
+            .post(format!("{}/api/articles/{}/comments", &self.address, slug))
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&comment_data)
+            .send()
+            .await
+            .expect("Failed to add comment");
+
+        let status = response.status();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .expect("Failed to parse comment response");
+
+        if !status.is_success() {
+            panic!("Comment creation failed with status {}: {:?}", status, body);
+        }
+
+        body["comment"]["id"]
+            .as_str()
+            .expect("Comment ID not found in response")
             .to_string()
     }
 }
@@ -564,6 +673,42 @@ pub fn assert_body_contains(body: &str, expected: &[&str]) {
         );
     }
 }
+
+/// Assert that the navbar shows authenticated state (username visible, no login/register links)
+pub fn assert_navbar_authenticated(body: &str, username: &str) {
+    // Username should be visible in navbar
+    assert!(
+        body.contains(username),
+        "Username '{}' should appear in navbar when authenticated",
+        username
+    );
+
+    // Login and Register links should not both be visible
+    let body_lowercase = body.to_lowercase();
+    let has_login_link =
+        body_lowercase.contains(">login<") || body_lowercase.contains("login</a>");
+    let has_register_link =
+        body_lowercase.contains(">register<") || body_lowercase.contains("register</a>");
+
+    assert!(
+        !(has_login_link && has_register_link),
+        "Login and Register links should not both be visible when user is authenticated"
+    );
+}
+
+/// Assert that an HTML page contains the expected JavaScript file with version
+pub fn assert_js_loaded(body: &str, js_file: &str, version: &str) {
+    let expected = format!("{}?v={}", js_file, version);
+    assert!(
+        body.contains(&expected),
+        "Expected JavaScript file '{}' with version '{}' not found in response",
+        js_file,
+        version
+    );
+}
+
+/// Get the current app version from Cargo.toml (matches APP_VERSION in templates)
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // ============================================================================
 // Test Fixture Builder

--- a/tests/api/rss.rs
+++ b/tests/api/rss.rs
@@ -1,7 +1,6 @@
 // tests/api/rss.rs
 
-use crate::helpers::{TestUserBuilder, spawn_app};
-use serde_json::json;
+use crate::helpers::{TestArticleBuilder, TestUserBuilder, spawn_app};
 
 #[tokio::test]
 async fn rss_feed_returns_valid_xml() {
@@ -43,29 +42,17 @@ async fn rss_feed_returns_valid_xml() {
 async fn rss_feed_includes_articles() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
 
-    // Register a user and create an article
-    let token = app
-        .register_user("testuser", "test@example.com", "password123")
-        .await;
-
-    // Create an article
-    let article_body = json!({
-        "article": {
-            "title": "Test Article for RSS",
-            "description": "This should appear in the RSS feed",
-            "body": "Article content here",
-            "tagList": ["test"]
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_body)
-        .send()
-        .await
-        .expect("Failed to execute request.");
+    // Create an article using helper
+    app.create_article(
+        &token,
+        "Test Article for RSS",
+        "This should appear in the RSS feed",
+        "Article content here",
+        vec!["test"],
+    )
+    .await;
 
     // Act - Get RSS feed
     let response = app
@@ -95,29 +82,17 @@ async fn rss_feed_includes_articles() {
 async fn rss_feed_escapes_xml_special_characters() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
 
-    // Register a user
-    let token = app
-        .register_user("testuser", "test@example.com", "password123")
-        .await;
-
-    // Create an article with special characters
-    let article_body = json!({
-        "article": {
-            "title": "Test & Special <Characters>",
-            "description": "Description with 'quotes' & \"tags\"",
-            "body": "Content",
-            "tagList": []
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_body)
-        .send()
-        .await
-        .expect("Failed to execute request.");
+    // Create an article with special characters using helper
+    app.create_article(
+        &token,
+        "Test & Special <Characters>",
+        "Description with 'quotes' & \"tags\"",
+        "Content",
+        vec![],
+    )
+    .await;
 
     // Act
     let response = app

--- a/tests/api/sitemap.rs
+++ b/tests/api/sitemap.rs
@@ -1,8 +1,7 @@
 // tests/api/sitemap.rs
 
-use crate::helpers::{TestUserBuilder, spawn_app};
+use crate::helpers::{TestArticleBuilder, TestUserBuilder, spawn_app};
 use reqwest::StatusCode;
-use serde_json::json;
 
 #[tokio::test]
 async fn sitemap_returns_valid_xml() {
@@ -82,29 +81,17 @@ async fn sitemap_includes_static_pages() {
 async fn sitemap_includes_articles() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("sitemapuser").await;
 
-    // Register a user and create an article
-    let token = app
-        .register_user("sitemapuser", "sitemap@example.com", "password123")
-        .await;
-
-    // Create an article
-    let article_body = json!({
-        "article": {
-            "title": "Sitemap Test Article",
-            "description": "This should appear in the sitemap",
-            "body": "Article content here",
-            "tagList": ["sitemap"]
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_body)
-        .send()
-        .await
-        .expect("Failed to execute request.");
+    // Create an article using helper
+    app.create_article(
+        &token,
+        "Sitemap Test Article",
+        "This should appear in the sitemap",
+        "Article content here",
+        vec!["sitemap"],
+    )
+    .await;
 
     // Act - Get sitemap
     let response = app
@@ -135,29 +122,17 @@ async fn sitemap_includes_articles() {
 async fn sitemap_escapes_xml_special_characters() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("xmluser").await;
 
-    // Register a user
-    let token = app
-        .register_user("xmluser", "xml@example.com", "password123")
-        .await;
-
-    // Create an article with special characters in title (which affects slug)
-    let article_body = json!({
-        "article": {
-            "title": "Test & Special <Characters>",
-            "description": "Testing XML escaping",
-            "body": "Content",
-            "tagList": []
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_body)
-        .send()
-        .await
-        .expect("Failed to execute request.");
+    // Create an article with special characters in title
+    app.create_article(
+        &token,
+        "Test & Special <Characters>",
+        "Testing XML escaping",
+        "Content",
+        vec![],
+    )
+    .await;
 
     // Act
     let response = app
@@ -173,8 +148,6 @@ async fn sitemap_escapes_xml_special_characters() {
     let body = response.text().await.expect("Failed to get response body");
 
     // The slug will be generated from the title, and should be properly escaped
-    // Even though the slug itself might not have special chars,
-    // we're testing that the XML is well-formed
     assert!(
         body.contains("</loc>"),
         "Should contain properly closed loc tags"
@@ -216,48 +189,26 @@ async fn sitemap_returns_valid_xml_when_no_articles() {
 async fn sitemap_excludes_draft_articles() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("draftuser").await;
 
-    // Register a user
-    let token = app
-        .register_user("draftuser", "draft@example.com", "password123")
-        .await;
+    // Create a published article using helper
+    app.create_article(
+        &token,
+        "Published Sitemap Article",
+        "This should appear in the sitemap",
+        "Published content",
+        vec![],
+    )
+    .await;
 
-    // Create a published article
-    let published_article = json!({
-        "article": {
-            "title": "Published Sitemap Article",
-            "description": "This should appear in the sitemap",
-            "body": "Published content",
-            "tagList": []
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&published_article)
-        .send()
-        .await
-        .expect("Failed to create published article");
-
-    // Create a draft article
-    let draft_article = json!({
-        "article": {
-            "title": "Draft Sitemap Article",
-            "description": "This should NOT appear in the sitemap",
-            "body": "Draft content",
-            "tagList": [],
-            "draft": true
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&draft_article)
-        .send()
-        .await
-        .expect("Failed to create draft article");
+    // Create a draft article using helper
+    app.create_draft_article(
+        &token,
+        "Draft Sitemap Article",
+        "This should NOT appear in the sitemap",
+        "Draft content",
+    )
+    .await;
 
     // Act - Get sitemap
     let response = app
@@ -289,32 +240,12 @@ async fn sitemap_excludes_draft_articles() {
 async fn sitemap_articles_sorted_by_update_time() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("sortuser").await;
 
-    // Register a user
-    let token = app
-        .register_user("sortuser", "sort@example.com", "password123")
-        .await;
-
-    // Create multiple articles
-    let articles = vec!["First Article", "Second Article", "Third Article"];
-
-    for title in articles {
-        let article_body = json!({
-            "article": {
-                "title": title,
-                "description": "Testing sort order",
-                "body": "Content",
-                "tagList": []
-            }
-        });
-
-        app.client
-            .post(format!("{}/api/articles", &app.address))
-            .header("Authorization", format!("Bearer {}", token))
-            .json(&article_body)
-            .send()
-            .await
-            .expect("Failed to execute request.");
+    // Create multiple articles using helper
+    for title in ["First Article", "Second Article", "Third Article"] {
+        app.create_article(&token, title, "Testing sort order", "Content", vec![])
+            .await;
     }
 
     // Act

--- a/tests/api/template_rendering.rs
+++ b/tests/api/template_rendering.rs
@@ -1,61 +1,35 @@
 // tests/api/template_rendering.rs
 
-use crate::helpers::{TestArticleBuilder, TestUserBuilder, spawn_app};
+use crate::helpers::{
+    assert_body_contains, assert_js_loaded, assert_navbar_authenticated, HtmlResponseValidator,
+    TestArticleBuilder, TestCommentBuilder, TestUserBuilder, APP_VERSION, spawn_app,
+};
 use reqwest::StatusCode;
-use serde_json::{Value, json};
 
 #[tokio::test]
 async fn test_article_template_renders_successfully_happy_path() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("templateuser").await;
 
-    // Register user and get token
-    let token = app
-        .register_user("templateuser", "template@example.com", "securepassword123")
+    // Create article with tags
+    let slug = app
+        .create_article(
+            &token,
+            "Template Rendering Test Article",
+            "Testing the template rendering system with JavaScript functionality",
+            "This article tests the template rendering functionality with comments and interactive elements.",
+            vec!["template", "testing", "javascript"],
+        )
         .await;
 
-    // Create an article to render
-    let article_data = json!({
-        "article": {
-            "title": "Template Rendering Test Article",
-            "description": "Testing the template rendering system with JavaScript functionality",
-            "body": "This article tests the template rendering functionality with comments and interactive elements.",
-            "tagList": ["template", "testing", "javascript"]
-        }
-    });
-
-    let create_response = app
-        .client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_data)
-        .send()
-        .await
-        .expect("Failed to create article");
-
-    let create_body: Value = create_response
-        .json()
-        .await
-        .expect("Failed to parse create response");
-
-    let slug = create_body["article"]["slug"].as_str().unwrap();
-
-    // Add a comment to test comment rendering
-    let comment_data = json!({
-        "comment": {
-            "body": "This is a test comment to verify the template renders comments correctly."
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles/{}/comments", &app.address, slug))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&comment_data)
-        .send()
-        .await
-        .expect("Failed to add comment");
+    // Add a comment
+    app.add_comment(
+        &token,
+        &slug,
+        "This is a test comment to verify the template renders comments correctly.",
+    )
+    .await;
 
     // Act - Access the article page
     let response = app
@@ -67,35 +41,23 @@ async fn test_article_template_renders_successfully_happy_path() {
 
     // Assert - Template should render successfully
     assert_eq!(response.status(), StatusCode::OK);
+    let body = response.assert_html_response().await;
 
-    // Verify content type is HTML
-    let content_type = response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-
-    assert!(content_type.contains("text/html") || content_type.is_empty());
-
-    // Get response body and verify template rendered correctly
-    let body = response.text().await.expect("Failed to get response body");
-
-    // Verify basic HTML structure
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-    assert!(body.contains("</html>"));
-
-    // Verify article content is rendered
-    assert!(body.contains("Template Rendering Test Article"));
-    assert!(body.contains("Testing the template rendering system"));
+    // Verify article content and tags
+    assert_body_contains(
+        &body,
+        &[
+            "Template Rendering Test Article",
+            "Testing the template rendering system",
+            "template",
+            "testing",
+            "javascript",
+            "</html>",
+        ],
+    );
 
     // Verify external JavaScript files are loaded with cache-busting
-    // Note: URLs are HTML-entity encoded in attributes (&#x2F; instead of /)
-    assert!(body.contains("article-page.js?v=2.13.3"));
-
-    // Verify tags are rendered
-    assert!(body.contains("template"));
-    assert!(body.contains("testing"));
-    assert!(body.contains("javascript"));
+    assert_js_loaded(&body, "article-page.js", APP_VERSION);
 }
 
 #[tokio::test]
@@ -117,69 +79,33 @@ async fn test_article_template_handles_nonexistent_article_failure_path() {
     // Assert - Should return 404 Not Found
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
-    // The response should be some form of error response
-    // (Either HTML error page or JSON error - both are valid for 404s)
     let body = response.text().await.expect("Failed to get response body");
-
-    // Should contain some indication this is a 404 error
-    assert!(
-        !body.is_empty(),
-        "Response body should not be empty for 404"
-    );
+    assert!(!body.is_empty(), "Response body should not be empty for 404");
 }
 
 #[tokio::test]
 async fn test_article_template_renders_with_comments() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("commenter").await;
 
-    // Register user
-    let token = app
-        .register_user("commenter", "commenter@example.com", "securepassword123")
+    // Create article and add comment
+    let slug = app
+        .create_article(
+            &token,
+            "Comments Test Article",
+            "Testing comment functionality in templates",
+            "This tests that comments render correctly in the template.",
+            vec!["comments", "test"],
+        )
         .await;
 
-    // Create an article
-    let article_data = json!({
-        "article": {
-            "title": "Comments Test Article",
-            "description": "Testing comment functionality in templates",
-            "body": "This tests that comments render correctly in the template.",
-            "tagList": ["comments", "test"]
-        }
-    });
-
-    let create_response = app
-        .client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_data)
-        .send()
-        .await
-        .expect("Failed to create article");
-
-    let create_body: Value = create_response
-        .json()
-        .await
-        .expect("Failed to parse create response");
-
-    let slug = create_body["article"]["slug"].as_str().unwrap();
-
-    // Add a comment
-    let comment_data = json!({
-        "comment": {
-            "body": "This is a test comment to verify template rendering."
-        }
-    });
-
-    app.client
-        .post(format!("{}/api/articles/{}/comments", &app.address, slug))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&comment_data)
-        .send()
-        .await
-        .expect("Failed to add comment");
+    app.add_comment(
+        &token,
+        &slug,
+        "This is a test comment to verify template rendering.",
+    )
+    .await;
 
     // Act - Access the article page
     let response = app
@@ -191,57 +117,27 @@ async fn test_article_template_renders_with_comments() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::OK);
+    let body = response.assert_html_response().await;
 
-    let body = response.text().await.expect("Failed to get response body");
-
-    // Verify the article loads correctly
-    assert!(body.contains("Comments Test Article"));
-
-    // Verify external JS files are loaded with cache-busting
-    // Note: URLs are HTML-entity encoded in attributes
-    assert!(body.contains("article-page.js?v=2.13.3"));
-
-    // Verify the template renders without JavaScript errors (basic validation)
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-    assert!(body.contains("</html>"));
+    assert_body_contains(&body, &["Comments Test Article", "</html>"]);
+    assert_js_loaded(&body, "article-page.js", APP_VERSION);
 }
 
 #[tokio::test]
 async fn test_template_compiles_without_javascript_errors() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("jstest").await;
 
-    // Register user
-    let token = app
-        .register_user("jstest", "jstest@example.com", "securepassword123")
+    let slug = app
+        .create_article(
+            &token,
+            "JavaScript Syntax Test",
+            "Testing that templates compile without JavaScript syntax errors",
+            "This tests that templates render correctly without syntax errors.",
+            vec!["javascript", "template"],
+        )
         .await;
-
-    // Create an article
-    let article_data = json!({
-        "article": {
-            "title": "JavaScript Syntax Test",
-            "description": "Testing that templates compile without JavaScript syntax errors",
-            "body": "This tests that templates render correctly without syntax errors.",
-            "tagList": ["javascript", "template"]
-        }
-    });
-
-    let create_response = app
-        .client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_data)
-        .send()
-        .await
-        .expect("Failed to create article");
-
-    let create_body: Value = create_response
-        .json()
-        .await
-        .expect("Failed to parse create response");
-
-    let slug = create_body["article"]["slug"].as_str().unwrap();
 
     // Act - Access the article page
     let response = app
@@ -253,60 +149,27 @@ async fn test_template_compiles_without_javascript_errors() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::OK);
+    let body = response.assert_html_response().await;
 
-    let body = response.text().await.expect("Failed to get response body");
-
-    // Verify the template renders without errors (primary concern after our fixes)
-    assert!(body.contains("JavaScript Syntax Test"));
-
-    // Verify external JS modules are loaded with cache-busting
-    // Note: URLs are HTML-entity encoded in attributes
-    assert!(body.contains("article-page.js?v=2.13.3"));
-
-    // The template should render complete HTML
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-    assert!(body.contains("</html>"));
-
-    // Should not be empty (indicates successful rendering)
-    assert!(!body.is_empty());
+    assert_body_contains(&body, &["JavaScript Syntax Test", "</html>"]);
+    assert_js_loaded(&body, "article-page.js", APP_VERSION);
 }
 
 #[tokio::test]
 async fn test_template_renders_consistently() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("consistent").await;
 
-    // Register user
-    let token = app
-        .register_user("consistent", "consistent@example.com", "securepassword123")
+    let slug = app
+        .create_article(
+            &token,
+            "Template Consistency Test",
+            "Testing template rendering consistency",
+            "This verifies templates render reliably after our fixes.",
+            vec!["consistency", "template"],
+        )
         .await;
-
-    // Create an article
-    let article_data = json!({
-        "article": {
-            "title": "Template Consistency Test",
-            "description": "Testing template rendering consistency",
-            "body": "This verifies templates render reliably after our fixes.",
-            "tagList": ["consistency", "template"]
-        }
-    });
-
-    let create_response = app
-        .client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_data)
-        .send()
-        .await
-        .expect("Failed to create article");
-
-    let create_body: Value = create_response
-        .json()
-        .await
-        .expect("Failed to parse create response");
-
-    let slug = create_body["article"]["slug"].as_str().unwrap();
 
     // Act - Access the article page multiple times
     let response1 = app
@@ -327,24 +190,12 @@ async fn test_template_renders_consistently() {
     assert_eq!(response1.status(), StatusCode::OK);
     assert_eq!(response2.status(), StatusCode::OK);
 
-    let body1 = response1
-        .text()
-        .await
-        .expect("Failed to get response body 1");
-    let body2 = response2
-        .text()
-        .await
-        .expect("Failed to get response body 2");
+    let body1 = response1.assert_html_response().await;
+    let body2 = response2.assert_html_response().await;
 
     // Verify core content is present in both responses
-    assert!(body1.contains("Template Consistency Test"));
-    assert!(body2.contains("Template Consistency Test"));
-    assert!(body1.contains("consistent"));
-    assert!(body2.contains("consistent"));
-
-    // Both responses should be valid HTML
-    assert!(body1.contains("<html") || body1.contains("<!DOCTYPE html"));
-    assert!(body2.contains("<html") || body2.contains("<!DOCTYPE html"));
+    assert_body_contains(&body1, &["Template Consistency Test", "consistent"]);
+    assert_body_contains(&body2, &["Template Consistency Test", "consistent"]);
 
     // Responses should be essentially the same (excluding timestamps)
     assert_eq!(
@@ -358,38 +209,17 @@ async fn test_template_renders_consistently() {
 async fn test_editor_page_shows_authenticated_user_in_navbar() {
     // Arrange
     let app = spawn_app().await;
+    let token = app.register_user_default("navbaruser").await;
 
-    // Register user
-    let token = app
-        .register_user("navbaruser", "navbar@example.com", "securepassword123")
+    let slug = app
+        .create_article(
+            &token,
+            "Navbar Authentication Test",
+            "Testing that navbar shows user when editing",
+            "This verifies the edit page includes user context in the template.",
+            vec!["navbar", "auth"],
+        )
         .await;
-
-    // Create an article to edit
-    let article_data = json!({
-        "article": {
-            "title": "Navbar Authentication Test",
-            "description": "Testing that navbar shows user when editing",
-            "body": "This verifies the edit page includes user context in the template.",
-            "tagList": ["navbar", "auth"]
-        }
-    });
-
-    let create_response = app
-        .client
-        .post(format!("{}/api/articles", &app.address))
-        .header("Content-Type", "application/json")
-        .header("Authorization", format!("Bearer {}", token))
-        .json(&article_data)
-        .send()
-        .await
-        .expect("Failed to create article");
-
-    let create_body: Value = create_response
-        .json()
-        .await
-        .expect("Failed to parse create response");
-
-    let slug = create_body["article"]["slug"].as_str().unwrap();
 
     // Act - Access the edit page with authentication
     let response = app
@@ -402,58 +232,23 @@ async fn test_editor_page_shows_authenticated_user_in_navbar() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::OK);
+    let body = response.assert_html_response().await;
 
-    let body = response.text().await.expect("Failed to get response body");
+    // Verify navbar shows authenticated state
+    assert_navbar_authenticated(&body, "navbaruser");
 
-    // Verify the page renders
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-    assert!(body.contains("</html>"));
-
-    // CRITICAL: Verify the username appears in the navbar
-    // This checks that user context was passed to the template
-    assert!(
-        body.contains("navbaruser"),
-        "Username should appear in navbar when editing article"
+    // Verify the editor form is present with article data
+    assert_body_contains(
+        &body,
+        &["articleForm", "Navbar Authentication Test"],
     );
-
-    // CRITICAL: Verify "Login" and "Register" buttons do NOT appear in visible navbar
-    // When authenticated, these should be hidden/not rendered in the active navbar
-    // Note: They might exist in template code, but shouldn't be in the rendered user-facing nav
-    let body_lowercase = body.to_lowercase();
-
-    // Check that we don't have both Login AND Register links visible together
-    // (which would indicate the unauthenticated navbar is showing)
-    let has_login_link = body_lowercase.contains(">login<") || body_lowercase.contains("login</a>");
-    let has_register_link =
-        body_lowercase.contains(">register<") || body_lowercase.contains("register</a>");
-
-    // If BOTH login and register are visible, user context is missing (the bug we fixed)
-    assert!(
-        !(has_login_link && has_register_link),
-        "Login and Register links should not both be visible when user is authenticated. \
-         This indicates missing user context in template (the bug we fixed)."
-    );
-
-    // Verify the editor form is present
-    assert!(body.contains("article-form") || body.contains("editor"));
-
-    // Verify the article data is pre-filled in the form
-    assert!(body.contains("Navbar Authentication Test"));
 }
 
 #[tokio::test]
 async fn test_new_article_editor_shows_authenticated_user_in_navbar() {
     // Arrange
     let app = spawn_app().await;
-
-    // Register user
-    let token = app
-        .register_user(
-            "neweditoruser",
-            "neweditor@example.com",
-            "securepassword123",
-        )
-        .await;
+    let token = app.register_user_default("neweditoruser").await;
 
     // Act - Access the new article editor page with authentication
     let response = app
@@ -466,38 +261,19 @@ async fn test_new_article_editor_shows_authenticated_user_in_navbar() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::OK);
+    let body = response.assert_html_response().await;
 
-    let body = response.text().await.expect("Failed to get response body");
-
-    // Verify the page renders
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-
-    // Verify the username appears in the navbar
-    assert!(
-        body.contains("neweditoruser"),
-        "Username should appear in navbar on new article editor page"
-    );
-
-    // Verify Login/Register links are not both visible (indicating authenticated state)
-    let body_lowercase = body.to_lowercase();
-    let has_login_link = body_lowercase.contains(">login<") || body_lowercase.contains("login</a>");
-    let has_register_link =
-        body_lowercase.contains(">register<") || body_lowercase.contains("register</a>");
-
-    assert!(
-        !(has_login_link && has_register_link),
-        "Login and Register links should not both be visible when user is authenticated"
-    );
+    // Verify navbar shows authenticated state
+    assert_navbar_authenticated(&body, "neweditoruser");
 }
 
 #[tokio::test]
 async fn test_homepage_shows_total_article_count() {
     // Arrange
     let app = spawn_app().await;
-
-    // Register user and create 10 articles (more than the 4 displayed on homepage)
     let token = app.register_user_default("testauthor").await;
 
+    // Create 10 articles (more than the 4 displayed on homepage)
     for i in 1..=10 {
         app.create_article_simple(&token, &format!("Article {}", i))
             .await;
@@ -513,22 +289,13 @@ async fn test_homepage_shows_total_article_count() {
 
     // Assert
     assert_eq!(response.status(), StatusCode::OK);
+    let body = response.assert_html_response().await;
 
-    let body = response.text().await.expect("Failed to get response body");
-
-    // Verify the page renders
-    assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
-    assert!(body.contains("</html>"));
-
-    // CRITICAL: Verify the total article count shows 10, not just 4
-    // The homepage should show the total count from the database,
-    // not just the count of articles displayed on the page
+    // Verify the total article count shows 10, not just 4
     assert!(
         body.contains(">10<") || body.contains("> 10 <"),
-        "Homepage should display total article count (10) from database, not just displayed articles (4)"
+        "Homepage should display total article count (10) from database"
     );
-
-    // Verify "Published Articles" label is present
     assert!(body.contains("Published Articles"));
 }
 
@@ -542,23 +309,8 @@ async fn test_homepage_shows_draft_widget_for_authenticated_user() {
 
     // Create 3 draft articles and 2 published articles
     for i in 1..=3 {
-        let article_data = json!({
-            "article": {
-                "title": format!("Draft Article {}", i),
-                "description": "This is a draft article",
-                "body": "Draft content",
-                "draft": true
-            }
-        });
-
-        app.client
-            .post(format!("{}/api/articles", &app.address))
-            .header("Authorization", format!("Bearer {}", token))
-            .header("Content-Type", "application/json")
-            .json(&article_data)
-            .send()
-            .await
-            .expect("Failed to create draft article");
+        app.create_draft_article_simple(&token, &format!("Draft Article {}", i))
+            .await;
     }
 
     for i in 1..=2 {
@@ -596,23 +348,8 @@ async fn test_homepage_draft_widget_hidden_for_guest_user() {
 
     // Create 5 draft articles
     for i in 1..=5 {
-        let article_data = json!({
-            "article": {
-                "title": format!("Draft Article {}", i),
-                "description": "This is a draft article",
-                "body": "Draft content",
-                "draft": true
-            }
-        });
-
-        app.client
-            .post(format!("{}/api/articles", &app.address))
-            .header("Authorization", format!("Bearer {}", token))
-            .header("Content-Type", "application/json")
-            .json(&article_data)
-            .send()
-            .await
-            .expect("Failed to create draft article");
+        app.create_draft_article_simple(&token, &format!("Draft Article {}", i))
+            .await;
     }
 
     // Act - Access the homepage without authentication
@@ -678,23 +415,8 @@ async fn test_homepage_separates_published_and_draft_counts() {
 
     // Create 3 draft articles
     for i in 1..=3 {
-        let article_data = json!({
-            "article": {
-                "title": format!("Draft Article {}", i),
-                "description": "This is a draft article",
-                "body": "Draft content",
-                "draft": true
-            }
-        });
-
-        app.client
-            .post(format!("{}/api/articles", &app.address))
-            .header("Authorization", format!("Bearer {}", token))
-            .header("Content-Type", "application/json")
-            .json(&article_data)
-            .send()
-            .await
-            .expect("Failed to create draft article");
+        app.create_draft_article_simple(&token, &format!("Draft Article {}", i))
+            .await;
     }
 
     // Act - Access the homepage while authenticated
@@ -711,14 +433,10 @@ async fn test_homepage_separates_published_and_draft_counts() {
     let body = response.text().await.expect("Failed to get response body");
 
     // Verify the page shows both counts separately
-    // Published count should be 5, NOT 8 (should exclude drafts)
     assert!(body.contains("Published Articles"));
-
-    // Draft count should be 3
     assert!(body.contains("Draft Articles"));
 
     // Verify that the total count shown is for published only (5), not including drafts
-    // The published articles widget should show 5, not 8
     let published_section = body.split("Published Articles").next().unwrap_or("");
     assert!(
         published_section.contains(">5<") || published_section.contains("> 5 <"),


### PR DESCRIPTION
- Add TestCommentBuilder trait with add_comment helper method
- Add create_draft_article and create_draft_article_simple to TestArticleBuilder
- Add assert_navbar_authenticated for navbar auth state assertions
- Add assert_js_loaded and APP_VERSION for JS cache-busting verification
- Refactor template_rendering.rs to use helpers (39% code reduction)
- Refactor sitemap.rs to use helpers (20% code reduction)
- Refactor rss.rs to use helpers (15% code reduction)
- Refactor feed_page.rs to use helpers

Net reduction: 247 lines removed from test files while maintaining the same test coverage and improving readability.