### PR TITLE
fix: preserve login state on 404 pages and fix Edit Profile link

### DIFF
--- a/src/lib/routes/error_pages.rs
+++ b/src/lib/routes/error_pages.rs
@@ -1,31 +1,58 @@
 // src/lib/routes/error_pages.rs
 
-use crate::{errors::ApiError, state::AppState};
+use crate::{auth::OptionalUser, errors::ApiError, state::AppState};
 use axum::{
     extract::{Request, State},
     http::StatusCode,
     response::{Html, IntoResponse},
 };
 use axum_macros::debug_handler;
-use serde::Serialize;
-
-#[derive(Debug, Serialize)]
-struct NotFoundPageContent {
-    title: String,
-    request_path: Option<String>,
-}
+use chrono::Datelike;
+use serde_json::json;
 
 #[debug_handler]
 pub async fn handle_404(
     State(state): State<AppState>,
+    optional_user: OptionalUser,
     request: Request,
 ) -> Result<impl IntoResponse, ApiError> {
     let request_path = request.uri().path().to_string();
 
-    let content = NotFoundPageContent {
-        title: "Page Not Found".to_string(),
-        request_path: Some(request_path),
+    // Get user info if authenticated
+    let user_info = if let Some(ref auth_user) = optional_user.user {
+        let conn = state.db.connect()?;
+        let mut rows = conn
+            .query(
+                "SELECT username, email, bio, image FROM users WHERE id = ?",
+                libsql::params![auth_user.user_id.to_string()],
+            )
+            .await?;
+
+        if let Some(row) = rows.next().await? {
+            let username: String = row.get(0)?;
+            let email: String = row.get(1)?;
+            let bio: Option<String> = row.get(2).ok();
+            let image: Option<String> = row.get(3).ok();
+
+            Some(json!({
+                "username": username,
+                "email": email,
+                "bio": bio,
+                "image": image
+            }))
+        } else {
+            None
+        }
+    } else {
+        None
     };
+
+    let content = json!({
+        "title": "Page Not Found",
+        "request_path": request_path,
+        "user": user_info,
+        "current_year": chrono::Utc::now().year(),
+    });
 
     let html = state
         .templates
@@ -38,11 +65,43 @@ pub async fn handle_404(
 #[debug_handler]
 pub async fn handle_404_simple(
     State(state): State<AppState>,
+    optional_user: OptionalUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    let content = NotFoundPageContent {
-        title: "Page Not Found".to_string(),
-        request_path: None,
+    // Get user info if authenticated
+    let user_info = if let Some(ref auth_user) = optional_user.user {
+        let conn = state.db.connect()?;
+        let mut rows = conn
+            .query(
+                "SELECT username, email, bio, image FROM users WHERE id = ?",
+                libsql::params![auth_user.user_id.to_string()],
+            )
+            .await?;
+
+        if let Some(row) = rows.next().await? {
+            let username: String = row.get(0)?;
+            let email: String = row.get(1)?;
+            let bio: Option<String> = row.get(2).ok();
+            let image: Option<String> = row.get(3).ok();
+
+            Some(json!({
+                "username": username,
+                "email": email,
+                "bio": bio,
+                "image": image
+            }))
+        } else {
+            None
+        }
+    } else {
+        None
     };
+
+    let content = json!({
+        "title": "Page Not Found",
+        "request_path": serde_json::Value::Null,
+        "user": user_info,
+        "current_year": chrono::Utc::now().year(),
+    });
 
     let html = state
         .templates

--- a/templates/profile/profile.html
+++ b/templates/profile/profile.html
@@ -52,7 +52,7 @@
                     </div>
                 {% elif current_user and current_user.username == profile.username %}
                     <div class="d-grid gap-2">
-                        <a href="/settings" class="btn btn-outline-primary">
+                        <a href="/account" class="btn btn-outline-primary">
                             <i class="fas fa-cog me-1"></i>
                             Edit Profile
                         </a>


### PR DESCRIPTION
- Changed Edit Profile link from /settings to /account (the actual route)
- Updated 404 handlers to use OptionalUser and pass user context to template
- 404 pages now show the logged-in user in the navbar