### PR TITLE
fix: optimize profile page queries and add pagination

### DIFF
--- a/src/lib/routes/profile.rs
+++ b/src/lib/routes/profile.rs
@@ -15,8 +15,14 @@ use axum::{
 };
 use axum_macros::debug_handler;
 use chrono::Datelike;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
+
+// Query parameters for profile page pagination
+#[derive(Debug, Deserialize)]
+pub struct ProfilePageQuery {
+    pub page: Option<i64>,
+}
 
 // struct type to represent a basic user profile for the template
 #[derive(Debug, Serialize)]
@@ -43,24 +49,43 @@ struct ArticleSummary {
     reading_time: i64,
 }
 
+// Default articles per page for profile
+const ARTICLES_PER_PAGE: i64 = 10;
+
 // handler which renders the profile page template
 #[debug_handler]
 pub async fn get_profile_page(
     State(state): State<AppState>,
     Path(username): Path<String>,
+    Query(query): Query<ProfilePageQuery>,
     optional_user: OptionalUser,
 ) -> Result<impl IntoResponse, ApiError> {
     let conn = state.db.connect()?;
 
-    // Fetch the profile user from the database
-    let mut user_rows = conn
+    // Pagination parameters
+    let current_page = query.page.unwrap_or(1).max(1);
+    let offset = (current_page - 1) * ARTICLES_PER_PAGE;
+
+    // Fetch profile user with article count, followers count, and following count in a single query
+    let mut profile_rows = conn
         .query(
-            "SELECT id, username, bio, image FROM users WHERE username = ?",
+            r#"
+            SELECT
+                u.id,
+                u.username,
+                u.bio,
+                u.image,
+                (SELECT COUNT(*) FROM articles WHERE author_id = u.id AND draft = 0) as articles_count,
+                (SELECT COUNT(*) FROM user_follows WHERE following_id = u.id) as followers_count,
+                (SELECT COUNT(*) FROM user_follows WHERE follower_id = u.id) as following_count
+            FROM users u
+            WHERE u.username = ?
+            "#,
             libsql::params![username.clone()],
         )
         .await?;
 
-    let profile_row = user_rows
+    let profile_row = profile_rows
         .next()
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("User '{}' not found", username)))?;
@@ -69,56 +94,33 @@ pub async fn get_profile_page(
     let profile_username: String = profile_row.get(1)?;
     let profile_bio: Option<String> = profile_row.get(2).ok();
     let profile_image: Option<String> = profile_row.get(3).ok();
+    let articles_count: i64 = profile_row.get(4)?;
+    let followers_count: i64 = profile_row.get(5)?;
+    let following_count: i64 = profile_row.get(6)?;
 
-    // Count published articles by this user
-    let mut articles_count_rows = conn
-        .query(
-            "SELECT COUNT(*) FROM articles WHERE author_id = ? AND draft = 0",
-            libsql::params![profile_id.clone()],
-        )
-        .await?;
-    let articles_count: i64 = articles_count_rows
-        .next()
-        .await?
-        .map(|row| row.get(0).unwrap_or(0))
-        .unwrap_or(0);
-
-    // Count followers (people following this user)
-    let mut followers_count_rows = conn
-        .query(
-            "SELECT COUNT(*) FROM user_follows WHERE following_id = ?",
-            libsql::params![profile_id.clone()],
-        )
-        .await?;
-    let followers_count: i64 = followers_count_rows
-        .next()
-        .await?
-        .map(|row| row.get(0).unwrap_or(0))
-        .unwrap_or(0);
-
-    // Count following (people this user follows)
-    let mut following_count_rows = conn
-        .query(
-            "SELECT COUNT(*) FROM user_follows WHERE follower_id = ?",
-            libsql::params![profile_id.clone()],
-        )
-        .await?;
-    let following_count: i64 = following_count_rows
-        .next()
-        .await?
-        .map(|row| row.get(0).unwrap_or(0))
-        .unwrap_or(0);
-
-    // Check if current user is following this profile
+    // Check if current user is following this profile and get current user info
     let mut is_following = false;
     let mut current_user_info: Option<serde_json::Value> = None;
 
     if let Some(ref auth_user) = optional_user.user {
-        // Get current user info for navbar
+        // Get current user info and following status in a single query
         let mut current_user_rows = conn
             .query(
-                "SELECT username, email, bio, image FROM users WHERE id = ?",
-                libsql::params![auth_user.user_id.to_string()],
+                r#"
+                SELECT
+                    u.username,
+                    u.email,
+                    u.bio,
+                    u.image,
+                    EXISTS(SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = ?) as is_following
+                FROM users u
+                WHERE u.id = ?
+                "#,
+                libsql::params![
+                    auth_user.user_id.to_string(),
+                    profile_id.clone(),
+                    auth_user.user_id.to_string()
+                ],
             )
             .await?;
 
@@ -127,6 +129,8 @@ pub async fn get_profile_page(
             let cu_email: String = row.get(1)?;
             let cu_bio: Option<String> = row.get(2).ok();
             let cu_image: Option<String> = row.get(3).ok();
+            let following_status: i64 = row.get(4).unwrap_or(0);
+            is_following = following_status == 1;
 
             current_user_info = Some(json!({
                 "username": cu_username,
@@ -135,18 +139,9 @@ pub async fn get_profile_page(
                 "image": cu_image
             }));
         }
-
-        // Check if following
-        let mut follow_rows = conn
-            .query(
-                "SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = ?",
-                libsql::params![auth_user.user_id.to_string(), profile_id.clone()],
-            )
-            .await?;
-        is_following = follow_rows.next().await?.is_some();
     }
 
-    // Fetch published articles by this user
+    // Fetch published articles with tags, favorites count, and comments count in a SINGLE optimized query
     let mut article_rows = conn
         .query(
             r#"
@@ -155,13 +150,20 @@ pub async fn get_profile_page(
                 a.slug,
                 a.description,
                 a.created_at,
-                a.id
+                GROUP_CONCAT(DISTINCT t.name) as tag_list,
+                COUNT(DISTINCT uf.user_id) as favorites_count,
+                COUNT(DISTINCT c.id) as comments_count
             FROM articles a
+            LEFT JOIN article_tags at ON a.id = at.article_id
+            LEFT JOIN tags t ON at.tag_id = t.id
+            LEFT JOIN user_favorites uf ON a.id = uf.article_id
+            LEFT JOIN comments c ON a.id = c.article_id
             WHERE a.author_id = ? AND a.draft = 0
+            GROUP BY a.id, a.title, a.slug, a.description, a.created_at
             ORDER BY a.created_at DESC
-            LIMIT 20
+            LIMIT ? OFFSET ?
             "#,
-            libsql::params![profile_id.clone()],
+            libsql::params![profile_id.clone(), ARTICLES_PER_PAGE, offset],
         )
         .await?;
 
@@ -171,54 +173,18 @@ pub async fn get_profile_page(
         let slug: String = row.get(1)?;
         let description: String = row.get(2).unwrap_or_default();
         let created_at: String = row.get(3)?;
-        let article_id: String = row.get(4)?;
-        // reading_time column doesn't exist in DB, use default estimate
+
+        // Get tags from GROUP_CONCAT result (comma-separated string)
+        let tag_list_str: Option<String> = row.get(4).ok();
+        let tags: Vec<String> = tag_list_str
+            .map(|s| s.split(',').map(|t| t.to_string()).collect())
+            .unwrap_or_default();
+
+        let favorites_count: i64 = row.get(5)?;
+        let comments_count: i64 = row.get(6)?;
+
+        // reading_time estimate based on typical reading speed
         let reading_time: i64 = 5;
-
-        // Get tags for this article
-        let mut tag_rows = conn
-            .query(
-                r#"
-                SELECT t.name
-                FROM tags t
-                JOIN article_tags at ON t.id = at.tag_id
-                WHERE at.article_id = ?
-                "#,
-                libsql::params![article_id.clone()],
-            )
-            .await?;
-
-        let mut tags: Vec<String> = Vec::new();
-        while let Some(tag_row) = tag_rows.next().await? {
-            let tag_name: String = tag_row.get(0)?;
-            tags.push(tag_name);
-        }
-
-        // Count favorites for this article
-        let mut fav_rows = conn
-            .query(
-                "SELECT COUNT(*) FROM user_favorites WHERE article_id = ?",
-                libsql::params![article_id.clone()],
-            )
-            .await?;
-        let favorites_count: i64 = fav_rows
-            .next()
-            .await?
-            .map(|r| r.get(0).unwrap_or(0))
-            .unwrap_or(0);
-
-        // Count comments for this article
-        let mut comment_rows = conn
-            .query(
-                "SELECT COUNT(*) FROM comments WHERE article_id = ?",
-                libsql::params![article_id.clone()],
-            )
-            .await?;
-        let comments_count: i64 = comment_rows
-            .next()
-            .await?
-            .map(|r| r.get(0).unwrap_or(0))
-            .unwrap_or(0);
 
         articles.push(ArticleSummary {
             title,
@@ -231,6 +197,13 @@ pub async fn get_profile_page(
             reading_time,
         });
     }
+
+    // Calculate pagination
+    let total_pages = ((articles_count as f64) / (ARTICLES_PER_PAGE as f64)).ceil() as i64;
+    let total_pages = total_pages.max(1); // At least 1 page
+
+    // Generate page numbers for pagination display
+    let pages: Vec<i64> = (1..=total_pages).collect();
 
     // Build profile data
     let profile = ProfileData {
@@ -252,8 +225,9 @@ pub async fn get_profile_page(
         "drafts": Vec::<ArticleSummary>::new(),
         "current_user": current_user_info,
         "user": current_user_info,
-        "current_page": 1,
-        "total_pages": 1,
+        "current_page": current_page,
+        "total_pages": total_pages,
+        "pages": pages,
         "current_year": chrono::Utc::now().year(),
     });
 

--- a/templates/profile/profile.html
+++ b/templates/profile/profile.html
@@ -109,7 +109,7 @@
             <li class="nav-item" role="presentation">
                 <button class="nav-link active" id="articles-tab" data-bs-toggle="tab" data-bs-target="#articles" type="button" role="tab">
                     <i class="fas fa-newspaper me-1"></i>
-                    Articles ({{ articles | length }})
+                    Articles ({{ profile.articles_count | default(value=0) }})
                 </button>
             </li>
             <li class="nav-item" role="presentation">

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -22,6 +22,7 @@ mod markdown_integration;
 mod media;
 mod newsletters;
 mod password_reset;
+mod profile;
 mod rbac;
 mod robots;
 mod rss;

--- a/tests/api/profile.rs
+++ b/tests/api/profile.rs
@@ -1,0 +1,380 @@
+// tests/api/profile.rs
+
+use crate::helpers::{
+    spawn_app, HtmlResponseValidator, TestArticleBuilder, TestCommentBuilder, TestFixture,
+};
+use crate::assert_status;
+use reqwest::StatusCode;
+
+#[tokio::test]
+async fn test_profile_page_returns_200_for_existing_user() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("testauthor")
+        .await
+        .promote_to_author("testauthor")
+        .await;
+
+    let token = fixture.get_token("testauthor");
+
+    // Act - Access profile page
+    let response = fixture
+        .app
+        .client
+        .get(format!("{}/profiles/testauthor", &fixture.app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    assert!(body.contains("testauthor"));
+}
+
+#[tokio::test]
+async fn test_profile_page_shows_articles() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("articleauthor")
+        .await
+        .promote_to_author("articleauthor")
+        .await;
+
+    let token = fixture.get_token("articleauthor");
+
+    // Create some articles
+    fixture
+        .app
+        .create_article(
+            &token,
+            "Test Article One",
+            "Description one",
+            "Body one",
+            vec!["rust", "testing"],
+        )
+        .await;
+
+    fixture
+        .app
+        .create_article(
+            &token,
+            "Test Article Two",
+            "Description two",
+            "Body two",
+            vec!["web"],
+        )
+        .await;
+
+    // Act - Access profile page
+    let response = fixture
+        .app
+        .client
+        .get(format!(
+            "{}/profiles/articleauthor",
+            &fixture.app.address
+        ))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    assert!(body.contains("Test Article One"));
+    assert!(body.contains("Test Article Two"));
+    assert!(body.contains("Articles (2)"));
+}
+
+#[tokio::test]
+async fn test_profile_page_shows_article_tags() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("tagauthor")
+        .await
+        .promote_to_author("tagauthor")
+        .await;
+
+    let token = fixture.get_token("tagauthor");
+
+    // Create an article with tags
+    fixture
+        .app
+        .create_article(
+            &token,
+            "Tagged Article",
+            "Description",
+            "Body content",
+            vec!["rust", "async"],
+        )
+        .await;
+
+    // Act - Access profile page
+    let response = fixture
+        .app
+        .client
+        .get(format!("{}/profiles/tagauthor", &fixture.app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    assert!(body.contains("rust"));
+    assert!(body.contains("async"));
+}
+
+#[tokio::test]
+async fn test_profile_page_pagination_with_many_articles() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("paginatedauthor")
+        .await
+        .promote_to_author("paginatedauthor")
+        .await;
+
+    let token = fixture.get_token("paginatedauthor");
+
+    // Create 15 articles (more than default page size of 10)
+    for i in 1..=15 {
+        fixture
+            .app
+            .create_article_simple(&token, &format!("Article {}", i))
+            .await;
+    }
+
+    // Act - Access first page
+    let response = fixture
+        .app
+        .client
+        .get(format!(
+            "{}/profiles/paginatedauthor",
+            &fixture.app.address
+        ))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert - First page should show pagination
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    assert!(body.contains("Articles (15)")); // Total count
+    assert!(body.contains("page=2")); // Link to page 2
+    assert!(body.contains("Next")); // Next button
+
+    // Act - Access second page
+    let response_page2 = fixture
+        .app
+        .client
+        .get(format!(
+            "{}/profiles/paginatedauthor?page=2",
+            &fixture.app.address
+        ))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert - Second page
+    assert_status!(response_page2, StatusCode::OK);
+    let body_page2 = response_page2.assert_html_response().await;
+    assert!(body_page2.contains("Previous")); // Previous button on page 2
+    assert!(body_page2.contains("page=1")); // Link to page 1
+}
+
+#[tokio::test]
+async fn test_profile_page_shows_favorites_count() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("favauthor")
+        .await
+        .with_user_default("fanliker")
+        .await
+        .promote_to_author("favauthor")
+        .await;
+
+    let author_token = fixture.get_token("favauthor");
+    let fan_token = fixture.get_token("fanliker");
+
+    // Create an article
+    let slug = fixture
+        .app
+        .create_article_simple(&author_token, "Popular Article")
+        .await;
+
+    // Favorite the article
+    fixture
+        .app
+        .client
+        .post(format!(
+            "{}/api/articles/{}/favorite",
+            &fixture.app.address, slug
+        ))
+        .header("Authorization", format!("Bearer {}", fan_token))
+        .send()
+        .await
+        .expect("Failed to favorite article");
+
+    // Act - Access profile page
+    let response = fixture
+        .app
+        .client
+        .get(format!("{}/profiles/favauthor", &fixture.app.address))
+        .header("Authorization", format!("Bearer {}", author_token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    // The template shows favorites with heart icon
+    assert!(body.contains("fa-heart"));
+}
+
+#[tokio::test]
+async fn test_profile_page_shows_comments_count() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("commentauthor")
+        .await
+        .with_user_default("commenter")
+        .await
+        .promote_to_author("commentauthor")
+        .await;
+
+    let author_token = fixture.get_token("commentauthor");
+    let commenter_token = fixture.get_token("commenter");
+
+    // Create an article
+    let slug = fixture
+        .app
+        .create_article_simple(&author_token, "Commentable Article")
+        .await;
+
+    // Add a comment
+    fixture.app.add_comment(&commenter_token, &slug, "Great article!").await;
+
+    // Act - Access profile page
+    let response = fixture
+        .app
+        .client
+        .get(format!("{}/profiles/commentauthor", &fixture.app.address))
+        .header("Authorization", format!("Bearer {}", author_token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    // The template shows comments with comment icon
+    assert!(body.contains("fa-comment"));
+}
+
+#[tokio::test]
+async fn test_profile_page_without_authentication() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("publicauthor")
+        .await
+        .promote_to_author("publicauthor")
+        .await;
+
+    let token = fixture.get_token("publicauthor");
+
+    // Create an article
+    fixture
+        .app
+        .create_article_simple(&token, "Public Article")
+        .await;
+
+    // Act - Access profile page without authentication
+    let response = fixture
+        .app
+        .client
+        .get(format!(
+            "{}/profiles/publicauthor",
+            &fixture.app.address
+        ))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert - Profile page should be accessible without auth
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    assert!(body.contains("publicauthor"));
+    assert!(body.contains("Public Article"));
+}
+
+#[tokio::test]
+async fn test_profile_page_returns_404_for_nonexistent_user() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act - Access profile page for nonexistent user
+    let response = app
+        .client
+        .get(format!("{}/profiles/nonexistentuser", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_profile_page_excludes_draft_articles() {
+    // Arrange
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("draftauthor")
+        .await
+        .promote_to_author("draftauthor")
+        .await;
+
+    let token = fixture.get_token("draftauthor");
+
+    // Create a published article
+    fixture
+        .app
+        .create_article_simple(&token, "Published Article")
+        .await;
+
+    // Create a draft article
+    fixture
+        .app
+        .create_draft_article_simple(&token, "Draft Article")
+        .await;
+
+    // Act - Access profile page
+    let response = fixture
+        .app
+        .client
+        .get(format!("{}/profiles/draftauthor", &fixture.app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let body = response.assert_html_response().await;
+    assert!(body.contains("Published Article"));
+    assert!(!body.contains("Draft Article")); // Draft should not appear in articles list
+    assert!(body.contains("Articles (1)")); // Only 1 published article
+}


### PR DESCRIPTION
- Replace N+1 queries with single optimized SQL query using JOINs and GROUP BY to fetch articles with tags, favorites, and comments counts
- Consolidate profile user stats (articles, followers, following) into single query with subqueries
- Add pagination support with page query parameter (10 articles/page)
- Update template to show total article count instead of page count
- Add comprehensive test suite for profile page functionality