### PR TITLE
fix: filter find authors list to show only authors and admins

### DIFF
--- a/src/lib/routes/users.rs
+++ b/src/lib/routes/users.rs
@@ -489,10 +489,11 @@ pub async fn list_profiles(
     let offset = query.offset.unwrap_or(0);
 
     // Build the query with optional search
+    // Only show users with Author or Admin role (not Subscribers)
     let (sql, params) = if let Some(search) = &query.search {
         let search_pattern = format!("%{}%", search);
         (
-            "SELECT id, username, bio, image FROM users WHERE username LIKE ? OR bio LIKE ? ORDER BY username LIMIT ? OFFSET ?".to_string(),
+            "SELECT id, username, bio, image FROM users WHERE (role = 'author' OR role = 'admin') AND (username LIKE ? OR bio LIKE ?) ORDER BY username LIMIT ? OFFSET ?".to_string(),
             vec![
                 libsql::Value::from(search_pattern.clone()),
                 libsql::Value::from(search_pattern),
@@ -502,7 +503,7 @@ pub async fn list_profiles(
         )
     } else {
         (
-            "SELECT id, username, bio, image FROM users ORDER BY username LIMIT ? OFFSET ?"
+            "SELECT id, username, bio, image FROM users WHERE role = 'author' OR role = 'admin' ORDER BY username LIMIT ? OFFSET ?"
                 .to_string(),
             vec![libsql::Value::from(limit), libsql::Value::from(offset)],
         )

--- a/tests/api/authors.rs
+++ b/tests/api/authors.rs
@@ -1,6 +1,6 @@
 // tests/api/authors.rs
 
-use crate::helpers::{TestUserBuilder, spawn_app};
+use crate::helpers::{TestFixture, TestUserBuilder, spawn_app};
 use crate::{assert_status, bearer_request, parse_json};
 use reqwest::StatusCode;
 use serde_json::Value;
@@ -23,19 +23,81 @@ async fn test_get_authors_requires_authentication() {
 }
 
 #[tokio::test]
-async fn test_get_authors_happy_path() {
-    // Arrange
-    let app = spawn_app().await;
-    let current_user_token = app.register_user_default("currentuser").await;
+async fn test_get_authors_only_shows_authors_not_subscribers() {
+    // Arrange - Create a fixture with an admin and users with different roles
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("admin") // First user becomes admin
+        .await
+        .with_user_default("author1")
+        .await
+        .with_user_default("subscriber1") // This user stays as subscriber
+        .await;
 
-    // Register other users to find
-    app.register_user_default("author1").await;
-    app.register_user_default("author2").await;
+    // Promote author1 to author role
+    let fixture = fixture.promote_to_author("author1").await;
+
+    let admin_token = fixture.get_token("admin");
+
+    // Act - Get list of profiles
+    let response = bearer_request!(
+        get & fixture.app,
+        format!("{}/api/profiles", &fixture.app.address),
+        &admin_token
+    )
+    .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let response_body: Value = parse_json!(response);
+
+    let profiles = response_body["profiles"].as_array().unwrap();
+    let usernames: Vec<&str> = profiles
+        .iter()
+        .map(|p| p["username"].as_str().unwrap())
+        .collect();
+
+    // author1 should be shown (has author role)
+    assert!(
+        usernames.contains(&"author1"),
+        "author1 should be visible in profiles"
+    );
+
+    // subscriber1 should NOT be shown (has subscriber role)
+    assert!(
+        !usernames.contains(&"subscriber1"),
+        "subscriber1 should NOT be visible in profiles (has subscriber role)"
+    );
+
+    // admin should NOT be shown (current user is excluded from results)
+    assert!(
+        !usernames.contains(&"admin"),
+        "admin (current user) should be excluded from results"
+    );
+}
+
+#[tokio::test]
+async fn test_get_authors_happy_path() {
+    // Arrange - Create fixture with admin and authors
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("currentuser") // First user becomes admin
+        .await
+        .with_user_default("author1")
+        .await
+        .with_user_default("author2")
+        .await;
+
+    // Promote authors
+    let fixture = fixture.promote_to_author("author1").await;
+    let fixture = fixture.promote_to_author("author2").await;
+
+    let current_user_token = fixture.get_token("currentuser");
 
     // Act - Get list of authors
     let response = bearer_request!(
-        get & app,
-        format!("{}/api/profiles", &app.address),
+        get & fixture.app,
+        format!("{}/api/profiles", &fixture.app.address),
         &current_user_token
     )
     .expect("Failed to execute request");
@@ -61,19 +123,28 @@ async fn test_get_authors_happy_path() {
 #[tokio::test]
 async fn test_get_authors_with_search() {
     // Arrange
-    let app = spawn_app().await;
-    let token = app.register_user_default("searcher").await;
-
-    // Register searchable authors
-    app.register_user("rustguru", "rustguru@example.com", "securepassword123")
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("searcher") // First user becomes admin
+        .await
+        .with_user_default("rustguru")
+        .await
+        .with_user_default("webdev")
+        .await
+        .with_user_default("pythonista")
         .await;
-    app.register_user_default("webdev").await;
-    app.register_user_default("pythonista").await;
+
+    // Promote all to author so they can be searched
+    let fixture = fixture.promote_to_author("rustguru").await;
+    let fixture = fixture.promote_to_author("webdev").await;
+    let fixture = fixture.promote_to_author("pythonista").await;
+
+    let token = fixture.get_token("searcher");
 
     // Act - Search for authors with "rust" in username
     let response = bearer_request!(
-        get & app,
-        format!("{}/api/profiles?search=rust", &app.address),
+        get & fixture.app,
+        format!("{}/api/profiles?search=rust", &fixture.app.address),
         &token
     )
     .expect("Failed to execute request");
@@ -94,25 +165,84 @@ async fn test_get_authors_with_search() {
 }
 
 #[tokio::test]
+async fn test_get_authors_search_excludes_subscribers() {
+    // Arrange - Create users where some match search but are subscribers
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("searcher") // First user becomes admin
+        .await
+        .with_user_default("rustauthor") // Will be promoted
+        .await
+        .with_user_default("rustsubscriber") // Will stay as subscriber
+        .await;
+
+    // Only promote rustauthor
+    let fixture = fixture.promote_to_author("rustauthor").await;
+
+    let token = fixture.get_token("searcher");
+
+    // Act - Search for "rust"
+    let response = bearer_request!(
+        get & fixture.app,
+        format!("{}/api/profiles?search=rust", &fixture.app.address),
+        &token
+    )
+    .expect("Failed to execute request");
+
+    // Assert
+    assert_status!(response, StatusCode::OK);
+    let response_body: Value = parse_json!(response);
+
+    let profiles = response_body["profiles"].as_array().unwrap();
+    let usernames: Vec<&str> = profiles
+        .iter()
+        .map(|p| p["username"].as_str().unwrap())
+        .collect();
+
+    // rustauthor should be found (author role)
+    assert!(
+        usernames.contains(&"rustauthor"),
+        "rustauthor should be found in search"
+    );
+
+    // rustsubscriber should NOT be found (subscriber role, even though username matches)
+    assert!(
+        !usernames.contains(&"rustsubscriber"),
+        "rustsubscriber should NOT be found (subscriber role)"
+    );
+}
+
+#[tokio::test]
 async fn test_get_authors_with_pagination() {
     // Arrange
-    let app = spawn_app().await;
-    let token = app.register_user_default("paginator").await;
-
-    // Register multiple authors
-    for i in 1..=5 {
-        app.register_user(
-            &format!("author{}", i),
-            &format!("author{}@example.com", i),
-            "securepassword123",
-        )
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("paginator") // First user becomes admin
+        .await
+        .with_user_default("author1")
+        .await
+        .with_user_default("author2")
+        .await
+        .with_user_default("author3")
+        .await
+        .with_user_default("author4")
+        .await
+        .with_user_default("author5")
         .await;
-    }
+
+    // Promote all to author
+    let fixture = fixture.promote_to_author("author1").await;
+    let fixture = fixture.promote_to_author("author2").await;
+    let fixture = fixture.promote_to_author("author3").await;
+    let fixture = fixture.promote_to_author("author4").await;
+    let fixture = fixture.promote_to_author("author5").await;
+
+    let token = fixture.get_token("paginator");
 
     // Act - Get first 3 authors
     let response = bearer_request!(
-        get & app,
-        format!("{}/api/profiles?limit=3", &app.address),
+        get & fixture.app,
+        format!("{}/api/profiles?limit=3", &fixture.app.address),
         &token
     )
     .expect("Failed to execute request");
@@ -129,16 +259,26 @@ async fn test_get_authors_with_pagination() {
 #[tokio::test]
 async fn test_get_authors_shows_follow_status() {
     // Arrange
-    let app = spawn_app().await;
-    let current_user_token = app.register_user_default("follower").await;
-
-    // Register author to follow
-    app.register_user("followme", "followme@example.com", "securepassword123")
+    let fixture = TestFixture::new()
+        .await
+        .with_user_default("follower") // First user becomes admin
+        .await
+        .with_user_default("followme")
         .await;
 
+    // Promote followme to author so they appear in the list
+    let fixture = fixture.promote_to_author("followme").await;
+
+    let current_user_token = fixture.get_token("follower");
+
     // Follow the author
-    app.client
-        .post(format!("{}/api/profiles/followme/follow", &app.address))
+    fixture
+        .app
+        .client
+        .post(format!(
+            "{}/api/profiles/followme/follow",
+            &fixture.app.address
+        ))
         .header("Authorization", format!("Bearer {}", current_user_token))
         .send()
         .await
@@ -146,8 +286,8 @@ async fn test_get_authors_shows_follow_status() {
 
     // Act - Get authors list
     let response = bearer_request!(
-        get & app,
-        format!("{}/api/profiles", &app.address),
+        get & fixture.app,
+        format!("{}/api/profiles", &fixture.app.address),
         &current_user_token
     )
     .expect("Failed to execute request");
@@ -216,4 +356,33 @@ async fn test_authors_page_with_authentication() {
     let body = response.text().await.expect("Failed to get response body");
     assert!(body.contains("<html") || body.contains("<!DOCTYPE html"));
     assert!(body.contains("Find Authors")); // Should contain the authors discovery title
+}
+
+#[tokio::test]
+async fn test_get_authors_empty_when_no_authors_exist() {
+    // Arrange - Only create subscribers (no authors)
+    let app = spawn_app().await;
+    let current_user_token = app.register_user_default("subscriber1").await;
+    app.register_user_default("subscriber2").await;
+    app.register_user_default("subscriber3").await;
+
+    // Act - Get list of authors (none exist, only subscribers)
+    let response = bearer_request!(
+        get & app,
+        format!("{}/api/profiles", &app.address),
+        &current_user_token
+    )
+    .expect("Failed to execute request");
+
+    // Assert - Should return empty list (first user is admin, but excluded as current user)
+    assert_status!(response, StatusCode::OK);
+    let response_body: Value = parse_json!(response);
+
+    let profiles = response_body["profiles"].as_array().unwrap();
+
+    // Should be empty - no authors (only subscribers, and admin is excluded as current user)
+    assert!(
+        profiles.is_empty(),
+        "Should return empty list when no authors exist (only subscribers)"
+    );
 }

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -35,25 +35,10 @@ static TRACING: LazyLock<()> = LazyLock::new(|| {
     }
 });
 
-// function to create R2 storage operator with dev bucket configuration
-fn create_r2_storage() -> Result<Operator, Box<dyn std::error::Error>> {
-    // Load environment variables from Secrets.dev.toml
-    let _ = dotenvy::from_filename("Secrets.dev.toml");
-
-    let builder = opendal::services::S3::default()
-        .region(&var("DEFAULT_REGION").unwrap_or_else(|_| "auto".to_string()))
-        .bucket(&var("BUCKET").unwrap_or_else(|_| "photo-bucket-dev".to_string()))
-        .endpoint(&var("ENDPOINT").unwrap_or_else(|_| {
-            "https://9f8f9b268ba5c7d97ad1adfabf962f30.r2.cloudflarestorage.com".to_string()
-        }))
-        .access_key_id(
-            &var("ACCESS_KEY_ID")
-                .unwrap_or_else(|_| "9063762cd3059516a2af26a159c7a5ca".to_string()),
-        )
-        .secret_access_key(&var("SECRET_ACCESS_KEY").unwrap_or_else(|_| {
-            "2c91ace42b2df0dd4d8c3d7dc36e8d59576e90dc55b8153d64da8086f87e4f16".to_string()
-        }));
-
+// function to create in-memory storage operator for testing
+fn create_test_storage() -> Result<Operator, Box<dyn std::error::Error>> {
+    // Use in-memory storage for tests - no cloud credentials needed
+    let builder = opendal::services::Memory::default();
     let op = Operator::new(builder)?.finish();
     Ok(op)
 }
@@ -134,7 +119,7 @@ pub async fn spawn_app() -> TestApp {
         .expect("Failed to run migrations");
 
     // Create R2 storage operator for testing with dev bucket
-    let operator = create_r2_storage().expect("Failed to create R2 storage operator for testing");
+    let operator = create_test_storage().expect("Failed to create test storage operator");
     let storage: Arc<dyn StorageBackend> = Arc::new(OpenDalStorage::new(operator));
 
     // set up the app state


### PR DESCRIPTION
The "find authors to follow" feature was incorrectly showing all users including subscribers. This fix updates the list_profiles() query to filter users by role (author or admin only).

- Updated SQL queries in list_profiles() to add role filter
- Rewrote tests to verify role filtering behavior using TestFixture
- Added new tests for edge cases (subscribers excluded, empty results)
- Switched test storage to in-memory backend for faster tests