### PR TITLE
feat: complete newsletter delivery feature with email sending

### DIFF
--- a/src/lib/email.rs
+++ b/src/lib/email.rs
@@ -717,6 +717,206 @@ impl EmailService {
     pub async fn send(&self, email: &Email) -> Result<SendResponse, SendError> {
         self.sender.send(email).await
     }
+
+    /// Send a newsletter subscription confirmation email
+    pub async fn send_newsletter_confirmation(
+        &self,
+        to_email: &str,
+        name: Option<&str>,
+        confirmation_token: &str,
+        base_url: &str,
+    ) -> Result<SendResponse, SendError> {
+        let confirmation_link = format!("{}/newsletter/confirmed/{}", base_url, confirmation_token);
+        let greeting = name
+            .map(|n| format!("Hi {},", n))
+            .unwrap_or_else(|| "Hi,".to_string());
+
+        let text_body = format!(
+            "{}\n\n\
+            Thank you for subscribing to the CrustyRustacean Dev Blog newsletter!\n\n\
+            Please confirm your subscription by clicking the link below:\n\
+            {}\n\n\
+            If you didn't subscribe to our newsletter, you can safely ignore this email.\n\n\
+            Best regards,\n\
+            CrustyRustacean Dev Blog Team",
+            greeting, confirmation_link
+        );
+
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confirm Your Newsletter Subscription</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+        <h1 style="color: white; margin: 0; font-size: 24px;">CrustyRustacean Dev Blog</h1>
+        <p style="color: rgba(255,255,255,0.9); margin: 10px 0 0 0;">Newsletter Subscription</p>
+    </div>
+    <div style="background: #ffffff; padding: 30px; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 10px 10px;">
+        <p style="font-size: 16px;">{}</p>
+        <p>Thank you for subscribing to the CrustyRustacean Dev Blog newsletter!</p>
+        <p>You'll receive:</p>
+        <ul style="padding-left: 20px;">
+            <li>Latest articles and tutorials</li>
+            <li>Rust tips and best practices</li>
+            <li>Updates from your favorite authors</li>
+        </ul>
+        <p>Please confirm your subscription by clicking the button below:</p>
+        <div style="text-align: center; margin: 30px 0;">
+            <a href="{}" style="display: inline-block; padding: 14px 28px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; border-radius: 6px; font-weight: bold; font-size: 16px;">
+                Confirm Subscription
+            </a>
+        </div>
+        <p style="color: #666; font-size: 14px;">Or copy and paste this link into your browser:</p>
+        <p style="word-break: break-all; color: #667eea; font-size: 14px;">{}</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 25px 0;">
+        <p style="color: #999; font-size: 12px; text-align: center;">
+            If you didn't subscribe to our newsletter, you can safely ignore this email.
+        </p>
+    </div>
+</body>
+</html>"#,
+            greeting, confirmation_link, confirmation_link
+        );
+
+        let email = Email::builder()
+            .from(self.sender_address())
+            .to(EmailAddress::new(to_email))
+            .subject("Confirm Your Newsletter Subscription - CrustyRustacean Dev Blog")
+            .body(text_body, html_body)
+            .build()?;
+
+        self.sender.send(&email).await
+    }
+
+    /// Send a newsletter issue to a subscriber
+    pub async fn send_newsletter_issue(
+        &self,
+        to_email: &str,
+        subscriber_name: Option<&str>,
+        subject: &str,
+        newsletter_title: &str,
+        newsletter_body: &str,
+        unsubscribe_token: &str,
+        base_url: &str,
+        author_articles: Option<&[AuthorArticleSummary]>,
+    ) -> Result<SendResponse, SendError> {
+        let unsubscribe_link = format!(
+            "{}/api/newsletters/unsubscribe/{}",
+            base_url, unsubscribe_token
+        );
+        let greeting = subscriber_name
+            .map(|n| format!("Hi {},", n))
+            .unwrap_or_else(|| "Hi,".to_string());
+
+        // Build author articles section if provided
+        let author_section_text = author_articles
+            .filter(|articles| !articles.is_empty())
+            .map(|articles| {
+                let mut section = String::from("\n\n--- FROM YOUR FAVORITE AUTHORS ---\n\n");
+                for article in articles {
+                    section.push_str(&format!(
+                        "* {} by {}\n  {}\n  Read more: {}\n\n",
+                        article.title, article.author_name, article.description, article.url
+                    ));
+                }
+                section
+            })
+            .unwrap_or_default();
+
+        let author_section_html = author_articles
+            .filter(|articles| !articles.is_empty())
+            .map(|articles| {
+                let mut section = String::from(
+                    r#"<div style="margin-top: 30px; padding-top: 20px; border-top: 2px solid #667eea;">
+                    <h2 style="color: #667eea; font-size: 18px; margin-bottom: 20px;">From Your Favorite Authors</h2>"#,
+                );
+                for article in articles {
+                    section.push_str(&format!(
+                        r#"<div style="margin-bottom: 20px; padding: 15px; background: #f8f9fa; border-radius: 8px;">
+                            <h3 style="margin: 0 0 5px 0; font-size: 16px;"><a href="{}" style="color: #333; text-decoration: none;">{}</a></h3>
+                            <p style="margin: 0 0 10px 0; color: #666; font-size: 14px;">by {}</p>
+                            <p style="margin: 0; color: #555; font-size: 14px;">{}</p>
+                        </div>"#,
+                        article.url, article.title, article.author_name, article.description
+                    ));
+                }
+                section.push_str("</div>");
+                section
+            })
+            .unwrap_or_default();
+
+        let text_body = format!(
+            "{}\n\n\
+            {}\n\n\
+            {}\
+            {}\n\n\
+            ---\n\
+            You're receiving this because you subscribed to our newsletter.\n\
+            Unsubscribe: {}\n\n\
+            Best regards,\n\
+            CrustyRustacean Dev Blog Team",
+            greeting, newsletter_title, newsletter_body, author_section_text, unsubscribe_link
+        );
+
+        let html_body = format!(
+            r#"<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{}</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background: #f5f5f5;">
+    <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+        <h1 style="color: white; margin: 0; font-size: 24px;">CrustyRustacean Dev Blog</h1>
+        <p style="color: rgba(255,255,255,0.9); margin: 10px 0 0 0;">Newsletter</p>
+    </div>
+    <div style="background: #ffffff; padding: 30px; border: 1px solid #e0e0e0; border-top: none;">
+        <p style="font-size: 16px;">{}</p>
+        <h2 style="color: #333; font-size: 22px; margin-top: 0;">{}</h2>
+        <div style="font-size: 15px; line-height: 1.8;">
+            {}
+        </div>
+        {}
+    </div>
+    <div style="background: #f8f9fa; padding: 20px; border: 1px solid #e0e0e0; border-top: none; border-radius: 0 0 10px 10px; text-align: center;">
+        <p style="color: #666; font-size: 12px; margin: 0 0 10px 0;">
+            You're receiving this email because you subscribed to our newsletter.
+        </p>
+        <a href="{}" style="color: #999; font-size: 12px;">Unsubscribe</a>
+    </div>
+</body>
+</html>"#,
+            newsletter_title,
+            greeting,
+            newsletter_title,
+            newsletter_body.replace('\n', "<br>"),
+            author_section_html,
+            unsubscribe_link
+        );
+
+        let email = Email::builder()
+            .from(self.sender_address())
+            .to(EmailAddress::new(to_email))
+            .subject(subject)
+            .body(text_body, html_body)
+            .build()?;
+
+        self.sender.send(&email).await
+    }
+}
+
+/// Summary of an article from a followed author for newsletter personalization
+#[derive(Debug, Clone)]
+pub struct AuthorArticleSummary {
+    pub title: String,
+    pub description: String,
+    pub author_name: String,
+    pub url: String,
 }
 
 // ============================================================================

--- a/src/lib/routes/newsletters.rs
+++ b/src/lib/routes/newsletters.rs
@@ -1,6 +1,7 @@
 // src/lib/routes/newsletters.rs
 
 use crate::auth::AuthorUser;
+use crate::email::AuthorArticleSummary;
 use crate::errors::ApiError;
 use crate::models::{
     CreateNewsletterIssue, NewsletterIssueResponse, NewsletterStats, SubscribeRequest,
@@ -11,19 +12,36 @@ use crate::state::AppState;
 use axum::{
     Json,
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{Html, IntoResponse},
 };
 use chrono::{Datelike, Utc};
 use libsql::params;
 use serde_json::json;
+use tracing::{error, info, warn};
 use uuid::Uuid;
 use validator::Validate;
+
+/// Helper to construct base URL from headers
+fn get_base_url(headers: &HeaderMap) -> String {
+    let host = headers
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("localhost:8000");
+
+    // In production, use HTTPS; for localhost, use HTTP
+    if host.contains("localhost") || host.contains("127.0.0.1") {
+        format!("http://{}", host)
+    } else {
+        format!("https://{}", host)
+    }
+}
 
 /// Subscribe to newsletter
 /// POST /api/newsletters/subscribe
 pub async fn subscribe(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<SubscribeRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     // Validate request
@@ -32,11 +50,12 @@ pub async fn subscribe(
     let conn = state.db.connect()?;
     let email = payload.email.to_lowercase();
     let name = payload.name;
+    let base_url = get_base_url(&headers);
 
     // Check if email already subscribed
     let mut existing = conn
         .query(
-            "SELECT id, confirmed, unsubscribed_at FROM newsletter_subscribers WHERE email = ?",
+            "SELECT id, confirmed, unsubscribed_at, confirmation_token FROM newsletter_subscribers WHERE email = ?",
             params![email.clone()],
         )
         .await?;
@@ -44,6 +63,7 @@ pub async fn subscribe(
     if let Some(row) = existing.next().await? {
         let confirmed: i64 = row.get(1)?;
         let unsubscribed_at: Option<String> = row.get(2)?;
+        let existing_token: Option<String> = row.get(3)?;
 
         // If already confirmed and not unsubscribed
         if confirmed == 1 && unsubscribed_at.is_none() {
@@ -58,18 +78,45 @@ pub async fn subscribe(
             let confirmation_token = Uuid::new_v4().to_string();
             conn.execute(
                 "UPDATE newsletter_subscribers SET confirmation_token = ?, unsubscribed_at = NULL, confirmed = 0, updated_at = ? WHERE email = ?",
-                params![confirmation_token, Utc::now().to_rfc3339(), email.clone()],
+                params![confirmation_token.clone(), Utc::now().to_rfc3339(), email.clone()],
             )
             .await?;
 
-            // TODO: Send confirmation email
+            // Send confirmation email
+            if let Err(e) = state
+                .email
+                .send_newsletter_confirmation(
+                    &email,
+                    name.as_deref(),
+                    &confirmation_token,
+                    &base_url,
+                )
+                .await
+            {
+                warn!("Failed to send newsletter confirmation email to {}: {}", email, e);
+            } else {
+                info!("Sent newsletter re-subscription confirmation to {}", email);
+            }
+
             return Ok(ApiResponse::success(json!({
                 "message": "Please check your email to confirm your subscription.",
                 "email": email
             })));
         }
 
-        // If not confirmed yet, resend confirmation
+        // If not confirmed yet, resend confirmation email
+        if let Some(token) = existing_token {
+            if let Err(e) = state
+                .email
+                .send_newsletter_confirmation(&email, name.as_deref(), &token, &base_url)
+                .await
+            {
+                warn!("Failed to resend newsletter confirmation email to {}: {}", email, e);
+            } else {
+                info!("Resent newsletter confirmation to {}", email);
+            }
+        }
+
         return Ok(ApiResponse::success(json!({
             "message": "A confirmation email has been sent. Please check your inbox.",
             "email": email
@@ -89,7 +136,7 @@ pub async fn subscribe(
             id.to_string(),
             email.clone(),
             name.clone(),
-            confirmation_token,
+            confirmation_token.clone(),
             unsubscribe_token,
             now.clone(),
             now.clone(),
@@ -98,7 +145,16 @@ pub async fn subscribe(
     )
     .await?;
 
-    // TODO: Send confirmation email with token
+    // Send confirmation email
+    if let Err(e) = state
+        .email
+        .send_newsletter_confirmation(&email, name.as_deref(), &confirmation_token, &base_url)
+        .await
+    {
+        warn!("Failed to send newsletter confirmation email to {}: {}", email, e);
+    } else {
+        info!("Sent newsletter confirmation email to {}", email);
+    }
 
     Ok(ApiResponse::success(json!({
         "message": "Please check your email to confirm your subscription.",
@@ -443,14 +499,24 @@ pub async fn delete_newsletter(
     })))
 }
 
+/// Subscriber info for sending newsletters
+struct SubscriberInfo {
+    id: String,
+    email: String,
+    name: Option<String>,
+    unsubscribe_token: String,
+}
+
 /// Send newsletter to all confirmed subscribers (author or admin)
 /// POST /api/admin/newsletters/:id/send
 pub async fn send_newsletter(
     _auth_user: AuthorUser,
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
     let conn = state.db.connect()?;
+    let base_url = get_base_url(&headers);
 
     // Get newsletter
     let mut rows = conn
@@ -465,6 +531,9 @@ pub async fn send_newsletter(
         .await?
         .ok_or_else(|| ApiError::NotFound("Newsletter not found".to_string()))?;
 
+    let newsletter_title: String = row.get(1)?;
+    let newsletter_subject: String = row.get(2)?;
+    let newsletter_body: String = row.get(3)?;
     let status: String = row.get(4)?;
 
     // Check if already sent
@@ -474,49 +543,188 @@ pub async fn send_newsletter(
         ));
     }
 
-    // Get all confirmed subscribers
-    let mut subscribers_rows = conn
-        .query(
-            "SELECT id, email, name FROM newsletter_subscribers WHERE confirmed = 1 AND unsubscribed_at IS NULL",
-            params![],
-        )
-        .await?;
-
-    // Collect subscriber IDs
-    let mut subscriber_ids = Vec::new();
-    while let Some(row) = subscribers_rows.next().await? {
-        let subscriber_id: String = row.get(0)?;
-        subscriber_ids.push(subscriber_id);
-    }
-
-    let subscriber_count = subscriber_ids.len();
-
-    // TODO: Implement actual email sending logic
-    // For now, we'll just create delivery logs with "sent" status
-
-    // Update newsletter status to "sent"
+    // Update newsletter status to "sending"
     let now = Utc::now().to_rfc3339();
     conn.execute(
-        "UPDATE newsletter_issues SET status = 'sent', sent_at = ?, recipient_count = ?, updated_at = ? WHERE id = ?",
-        params![now.clone(), subscriber_count as i32, now.clone(), id.clone()],
+        "UPDATE newsletter_issues SET status = 'sending', updated_at = ? WHERE id = ?",
+        params![now.clone(), id.clone()],
     )
     .await?;
 
-    // Create delivery logs for all subscribers
-    for subscriber_id in subscriber_ids {
-        let log_id = Uuid::new_v4();
-
-        conn.execute(
-            "INSERT INTO newsletter_delivery_logs (id, issue_id, subscriber_id, status, sent_at, created_at) VALUES (?, ?, ?, 'sent', ?, ?)",
-            params![log_id.to_string(), id.clone(), subscriber_id, now.clone(), now.clone()],
+    // Get all confirmed subscribers who haven't received this newsletter yet (idempotency)
+    let mut subscribers_rows = conn
+        .query(
+            r"SELECT ns.id, ns.email, ns.name, ns.unsubscribe_token
+              FROM newsletter_subscribers ns
+              WHERE ns.confirmed = 1
+              AND ns.unsubscribed_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM newsletter_delivery_logs dl
+                  WHERE dl.subscriber_id = ns.id
+                  AND dl.issue_id = ?
+              )",
+            params![id.clone()],
         )
         .await?;
+
+    // Collect subscriber info
+    let mut subscribers: Vec<SubscriberInfo> = Vec::new();
+    while let Some(row) = subscribers_rows.next().await? {
+        subscribers.push(SubscriberInfo {
+            id: row.get(0)?,
+            email: row.get(1)?,
+            name: row.get(2).ok(),
+            unsubscribe_token: row.get(3)?,
+        });
     }
 
+    let total_subscribers = subscribers.len();
+    let mut sent_count = 0;
+    let mut failed_count = 0;
+
+    // Send emails to each subscriber
+    for subscriber in subscribers {
+        // Get personalized content: recent articles from authors this subscriber's user follows
+        // Note: Newsletter subscribers may not have a user account, so this is optional
+        let author_articles = get_followed_author_articles(
+            &conn,
+            &subscriber.email,
+            &base_url,
+        )
+        .await
+        .unwrap_or_default();
+
+        let author_articles_ref: Option<&[AuthorArticleSummary]> = if author_articles.is_empty() {
+            None
+        } else {
+            Some(&author_articles)
+        };
+
+        // Create delivery log entry with "pending" status
+        let log_id = Uuid::new_v4();
+        let send_time = Utc::now().to_rfc3339();
+
+        conn.execute(
+            "INSERT INTO newsletter_delivery_logs (id, issue_id, subscriber_id, status, created_at) VALUES (?, ?, ?, 'pending', ?)",
+            params![log_id.to_string(), id.clone(), subscriber.id.clone(), send_time.clone()],
+        )
+        .await?;
+
+        // Send the email
+        match state
+            .email
+            .send_newsletter_issue(
+                &subscriber.email,
+                subscriber.name.as_deref(),
+                &newsletter_subject,
+                &newsletter_title,
+                &newsletter_body,
+                &subscriber.unsubscribe_token,
+                &base_url,
+                author_articles_ref,
+            )
+            .await
+        {
+            Ok(_) => {
+                // Update delivery log to "sent"
+                conn.execute(
+                    "UPDATE newsletter_delivery_logs SET status = 'sent', sent_at = ? WHERE id = ?",
+                    params![Utc::now().to_rfc3339(), log_id.to_string()],
+                )
+                .await?;
+                sent_count += 1;
+                info!("Newsletter {} sent to {}", id, subscriber.email);
+            }
+            Err(e) => {
+                // Update delivery log to "failed" with error message
+                conn.execute(
+                    "UPDATE newsletter_delivery_logs SET status = 'failed', error_message = ? WHERE id = ?",
+                    params![e.to_string(), log_id.to_string()],
+                )
+                .await?;
+                failed_count += 1;
+                error!(
+                    "Failed to send newsletter {} to {}: {}",
+                    id, subscriber.email, e
+                );
+            }
+        }
+    }
+
+    // Update newsletter status based on results
+    let final_status = if failed_count == 0 {
+        "sent"
+    } else if sent_count == 0 {
+        "failed"
+    } else {
+        "sent" // Partial success still counts as sent
+    };
+
+    conn.execute(
+        "UPDATE newsletter_issues SET status = ?, sent_at = ?, recipient_count = ?, updated_at = ? WHERE id = ?",
+        params![final_status, Utc::now().to_rfc3339(), sent_count as i32, Utc::now().to_rfc3339(), id.clone()],
+    )
+    .await?;
+
+    let message = if failed_count > 0 {
+        format!(
+            "Newsletter sent to {} of {} subscribers ({} failed)",
+            sent_count, total_subscribers, failed_count
+        )
+    } else {
+        format!("Newsletter sent to {} subscribers", sent_count)
+    };
+
+    info!("{}", message);
+
     Ok(ApiResponse::success(json!({
-        "message": format!("Newsletter sent to {} subscribers", subscriber_count),
-        "recipient_count": subscriber_count
+        "message": message,
+        "recipient_count": sent_count,
+        "failed_count": failed_count
     })))
+}
+
+/// Get recent articles from authors that a subscriber follows (via their user account)
+/// Returns empty vec if subscriber has no linked user account or doesn't follow anyone
+async fn get_followed_author_articles(
+    conn: &libsql::Connection,
+    subscriber_email: &str,
+    base_url: &str,
+) -> Result<Vec<AuthorArticleSummary>, libsql::Error> {
+    // Try to find a user account with this email that follows some authors
+    // Then get recent articles from those followed authors (last 30 days)
+    let mut rows = conn
+        .query(
+            r"SELECT a.title, a.description, a.slug, u.username
+              FROM articles a
+              JOIN users u ON a.author_id = u.id
+              JOIN user_follows uf ON uf.following_id = u.id
+              JOIN users subscriber_user ON uf.follower_id = subscriber_user.id
+              WHERE subscriber_user.email = ?
+              AND a.draft = 0
+              AND datetime(a.created_at) >= datetime('now', '-30 days')
+              ORDER BY a.created_at DESC
+              LIMIT 5",
+            params![subscriber_email],
+        )
+        .await?;
+
+    let mut articles = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let title: String = row.get(0)?;
+        let description: String = row.get(1)?;
+        let slug: String = row.get(2)?;
+        let author_name: String = row.get(3)?;
+
+        articles.push(AuthorArticleSummary {
+            title,
+            description,
+            author_name,
+            url: format!("{}/articles/{}", base_url, slug),
+        });
+    }
+
+    Ok(articles)
 }
 
 /// Get newsletter statistics (author or admin)

--- a/templates/admin/newsletters.html
+++ b/templates/admin/newsletters.html
@@ -5,52 +5,53 @@
 {% block content %}
 <div class="row">
     <div class="col-12">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <h1>
+        <!-- Header - Stack on mobile, inline on larger screens -->
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4 gap-2">
+            <h1 class="h3 h2-md mb-0">
                 <i class="fas fa-envelope me-2"></i>
                 Newsletter Management
             </h1>
-            <a href="/admin" class="btn btn-outline-secondary">
+            <a href="/admin" class="btn btn-outline-secondary btn-sm btn-md-normal">
                 <i class="fas fa-arrow-left me-2"></i>
                 Back to Admin
             </a>
         </div>
 
-        <!-- Newsletter Statistics -->
-        <div class="row mb-4" id="stats-container">
-            <div class="col-md-3">
-                <div class="card text-center">
-                    <div class="card-body">
+        <!-- Newsletter Statistics - 2x2 grid on mobile, 4-column on larger screens -->
+        <div class="row mb-4 g-3" id="stats-container">
+            <div class="col-6 col-md-3">
+                <div class="card text-center h-100">
+                    <div class="card-body py-3">
                         <i class="fas fa-users fa-2x text-primary mb-2"></i>
-                        <h3 class="mb-0" id="total-subscribers">-</h3>
-                        <p class="text-muted mb-0">Total Subscribers</p>
+                        <h3 class="mb-0 fs-4" id="total-subscribers">-</h3>
+                        <p class="text-muted mb-0 small">Total Subscribers</p>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
-                    <div class="card-body">
+            <div class="col-6 col-md-3">
+                <div class="card text-center h-100">
+                    <div class="card-body py-3">
                         <i class="fas fa-check-circle fa-2x text-success mb-2"></i>
-                        <h3 class="mb-0" id="confirmed-subscribers">-</h3>
-                        <p class="text-muted mb-0">Confirmed</p>
+                        <h3 class="mb-0 fs-4" id="confirmed-subscribers">-</h3>
+                        <p class="text-muted mb-0 small">Confirmed</p>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
-                    <div class="card-body">
+            <div class="col-6 col-md-3">
+                <div class="card text-center h-100">
+                    <div class="card-body py-3">
                         <i class="fas fa-newspaper fa-2x text-info mb-2"></i>
-                        <h3 class="mb-0" id="total-issues">-</h3>
-                        <p class="text-muted mb-0">Total Issues</p>
+                        <h3 class="mb-0 fs-4" id="total-issues">-</h3>
+                        <p class="text-muted mb-0 small">Total Issues</p>
                     </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <div class="card text-center">
-                    <div class="card-body">
+            <div class="col-6 col-md-3">
+                <div class="card text-center h-100">
+                    <div class="card-body py-3">
                         <i class="fas fa-paper-plane fa-2x text-warning mb-2"></i>
-                        <h3 class="mb-0" id="sent-issues">-</h3>
-                        <p class="text-muted mb-0">Sent</p>
+                        <h3 class="mb-0 fs-4" id="sent-issues">-</h3>
+                        <p class="text-muted mb-0 small">Sent</p>
                     </div>
                 </div>
             </div>

--- a/tests/api/newsletters.rs
+++ b/tests/api/newsletters.rs
@@ -625,3 +625,431 @@ async fn test_admin_newsletters_page_requires_authentication() {
     // Assert
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
+
+#[tokio::test]
+async fn test_send_newsletter_is_idempotent() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("author").await;
+
+    // Create and confirm a subscriber
+    let subscribe_data = json!({
+        "email": "idempotent@example.com",
+        "name": "Idempotent Test"
+    });
+
+    let _ = app
+        .client
+        .post(format!("{}/api/newsletters/subscribe", &app.address))
+        .header("Content-Type", "application/json")
+        .json(&subscribe_data)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Confirm the subscription
+    let confirm_token = {
+        let conn = app.db.connect().expect("Failed to connect to database");
+        let mut rows = conn
+            .query(
+                "SELECT confirmation_token FROM newsletter_subscribers WHERE email = 'idempotent@example.com'",
+                libsql::params![],
+            )
+            .await
+            .expect("Failed to query database");
+
+        let row = rows
+            .next()
+            .await
+            .expect("Failed to get row")
+            .expect("No subscriber found");
+        row.get::<String>(0).expect("Failed to get token")
+    };
+
+    let _ = app
+        .client
+        .post(format!(
+            "{}/api/newsletters/confirm/{}",
+            &app.address, confirm_token
+        ))
+        .send()
+        .await
+        .expect("Failed to confirm subscription");
+
+    // Create a newsletter
+    let newsletter_data = json!({
+        "title": "Idempotent Test Newsletter",
+        "subject": "Testing Idempotency",
+        "body": "This newsletter tests idempotent delivery"
+    });
+
+    let create_response = app
+        .client
+        .post(format!("{}/api/admin/newsletters", &app.address))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&newsletter_data)
+        .send()
+        .await
+        .expect("Failed to create newsletter");
+
+    let create_body: Value = create_response
+        .json()
+        .await
+        .expect("Failed to parse response");
+    let newsletter_id = create_body["data"]["id"].as_str().unwrap();
+
+    // Act - Send newsletter first time
+    let first_send = app
+        .client
+        .post(format!(
+            "{}/api/admin/newsletters/{}/send",
+            &app.address, newsletter_id
+        ))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to send newsletter first time");
+
+    assert_eq!(first_send.status(), StatusCode::OK);
+    let first_body: Value = first_send.json().await.expect("Failed to parse response");
+    assert_eq!(first_body["data"]["recipient_count"], 1);
+
+    // Act - Try to send again (should fail because already sent)
+    let second_send = app
+        .client
+        .post(format!(
+            "{}/api/admin/newsletters/{}/send",
+            &app.address, newsletter_id
+        ))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to send newsletter second time");
+
+    // Assert - Second send should return an error because newsletter is already sent
+    assert_eq!(second_send.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_delivery_logs_are_created() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("author").await;
+
+    // Create and confirm a subscriber
+    let subscribe_data = json!({
+        "email": "delivery-log@example.com",
+        "name": "Delivery Log Test"
+    });
+
+    let _ = app
+        .client
+        .post(format!("{}/api/newsletters/subscribe", &app.address))
+        .header("Content-Type", "application/json")
+        .json(&subscribe_data)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Get and confirm the subscription token
+    let confirm_token = {
+        let conn = app.db.connect().expect("Failed to connect to database");
+        let mut rows = conn
+            .query(
+                "SELECT confirmation_token FROM newsletter_subscribers WHERE email = 'delivery-log@example.com'",
+                libsql::params![],
+            )
+            .await
+            .expect("Failed to query database");
+        let row = rows.next().await.expect("Failed to get row").expect("No subscriber");
+        row.get::<String>(0).expect("Failed to get token")
+    };
+
+    let _ = app
+        .client
+        .post(format!("{}/api/newsletters/confirm/{}", &app.address, confirm_token))
+        .send()
+        .await
+        .expect("Failed to confirm subscription");
+
+    // Create a newsletter
+    let newsletter_data = json!({
+        "title": "Delivery Log Test",
+        "subject": "Testing Delivery Logs",
+        "body": "This newsletter tests delivery log creation"
+    });
+
+    let create_response = app
+        .client
+        .post(format!("{}/api/admin/newsletters", &app.address))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&newsletter_data)
+        .send()
+        .await
+        .expect("Failed to create newsletter");
+
+    let create_body: Value = create_response.json().await.expect("Failed to parse response");
+    let newsletter_id = create_body["data"]["id"].as_str().unwrap();
+
+    // Act - Send newsletter
+    let _ = app
+        .client
+        .post(format!("{}/api/admin/newsletters/{}/send", &app.address, newsletter_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to send newsletter");
+
+    // Assert - Check delivery log was created
+    let conn = app.db.connect().expect("Failed to connect to database");
+    let mut rows = conn
+        .query(
+            "SELECT status FROM newsletter_delivery_logs WHERE issue_id = ?",
+            libsql::params![newsletter_id],
+        )
+        .await
+        .expect("Failed to query delivery logs");
+
+    let row = rows.next().await.expect("Failed to get row").expect("No delivery log found");
+    let status: String = row.get(0).expect("Failed to get status");
+    assert_eq!(status, "sent");
+}
+
+#[tokio::test]
+async fn test_resubscribe_after_unsubscribe() {
+    // Arrange
+    let app = spawn_app().await;
+
+    let subscribe_data = json!({
+        "email": "resubscribe@example.com",
+        "name": "Resubscribe Test"
+    });
+
+    // First subscription
+    let _ = app
+        .client
+        .post(format!("{}/api/newsletters/subscribe", &app.address))
+        .header("Content-Type", "application/json")
+        .json(&subscribe_data)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Get tokens
+    let (confirm_token, unsubscribe_token) = {
+        let conn = app.db.connect().expect("Failed to connect to database");
+        let mut rows = conn
+            .query(
+                "SELECT confirmation_token, unsubscribe_token FROM newsletter_subscribers WHERE email = 'resubscribe@example.com'",
+                libsql::params![],
+            )
+            .await
+            .expect("Failed to query database");
+        let row = rows.next().await.expect("Failed to get row").expect("No subscriber");
+        (
+            row.get::<String>(0).expect("Failed to get confirm token"),
+            row.get::<String>(1).expect("Failed to get unsubscribe token"),
+        )
+    };
+
+    // Confirm subscription
+    let _ = app
+        .client
+        .post(format!("{}/api/newsletters/confirm/{}", &app.address, confirm_token))
+        .send()
+        .await
+        .expect("Failed to confirm subscription");
+
+    // Unsubscribe
+    let _ = app
+        .client
+        .post(format!("{}/api/newsletters/unsubscribe/{}", &app.address, unsubscribe_token))
+        .send()
+        .await
+        .expect("Failed to unsubscribe");
+
+    // Act - Resubscribe
+    let resubscribe_response = app
+        .client
+        .post(format!("{}/api/newsletters/subscribe", &app.address))
+        .header("Content-Type", "application/json")
+        .json(&subscribe_data)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(resubscribe_response.status(), StatusCode::OK);
+    let response_body: Value = resubscribe_response.json().await.expect("Failed to parse response");
+    assert!(response_body["data"]["message"].as_str().unwrap().contains("check your email"));
+
+    // Verify subscriber is no longer marked as unsubscribed
+    let conn = app.db.connect().expect("Failed to connect to database");
+    let mut rows = conn
+        .query(
+            "SELECT unsubscribed_at, confirmed FROM newsletter_subscribers WHERE email = 'resubscribe@example.com'",
+            libsql::params![],
+        )
+        .await
+        .expect("Failed to query database");
+    let row = rows.next().await.expect("Failed to get row").expect("No subscriber");
+    let unsubscribed_at: Option<String> = row.get(0).ok();
+    let confirmed: i64 = row.get(1).expect("Failed to get confirmed");
+
+    assert!(unsubscribed_at.is_none(), "Should not be unsubscribed");
+    assert_eq!(confirmed, 0, "Should need to reconfirm");
+}
+
+#[tokio::test]
+async fn test_newsletter_send_with_no_subscribers() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("author").await;
+
+    // Create a newsletter without any subscribers
+    let newsletter_data = json!({
+        "title": "No Subscribers Test",
+        "subject": "Testing with No Subscribers",
+        "body": "This newsletter has no subscribers"
+    });
+
+    let create_response = app
+        .client
+        .post(format!("{}/api/admin/newsletters", &app.address))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&newsletter_data)
+        .send()
+        .await
+        .expect("Failed to create newsletter");
+
+    let create_body: Value = create_response.json().await.expect("Failed to parse response");
+    let newsletter_id = create_body["data"]["id"].as_str().unwrap();
+
+    // Act - Send newsletter with no subscribers
+    let send_response = app
+        .client
+        .post(format!("{}/api/admin/newsletters/{}/send", &app.address, newsletter_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to send newsletter");
+
+    // Assert - Should succeed with 0 recipients
+    assert_eq!(send_response.status(), StatusCode::OK);
+    let response_body: Value = send_response.json().await.expect("Failed to parse response");
+    assert_eq!(response_body["data"]["recipient_count"], 0);
+}
+
+#[tokio::test]
+async fn test_update_newsletter() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("author").await;
+
+    // Create a newsletter
+    let newsletter_data = json!({
+        "title": "Original Title",
+        "subject": "Original Subject",
+        "body": "Original body content"
+    });
+
+    let create_response = app
+        .client
+        .post(format!("{}/api/admin/newsletters", &app.address))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&newsletter_data)
+        .send()
+        .await
+        .expect("Failed to create newsletter");
+
+    let create_body: Value = create_response.json().await.expect("Failed to parse response");
+    let newsletter_id = create_body["data"]["id"].as_str().unwrap();
+
+    // Act - Update the newsletter
+    let update_data = json!({
+        "title": "Updated Title",
+        "body": "Updated body content"
+    });
+
+    let update_response = app
+        .client
+        .put(format!("{}/api/admin/newsletters/{}", &app.address, newsletter_id))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&update_data)
+        .send()
+        .await
+        .expect("Failed to update newsletter");
+
+    // Assert
+    assert_eq!(update_response.status(), StatusCode::OK);
+
+    // Verify the update
+    let get_response = app
+        .client
+        .get(format!("{}/api/admin/newsletters/{}", &app.address, newsletter_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to get newsletter");
+
+    let get_body: Value = get_response.json().await.expect("Failed to parse response");
+    assert_eq!(get_body["data"]["newsletter"]["title"], "Updated Title");
+    assert_eq!(get_body["data"]["newsletter"]["body"], "Updated body content");
+    // Subject should remain unchanged
+    assert_eq!(get_body["data"]["newsletter"]["subject"], "Original Subject");
+}
+
+#[tokio::test]
+async fn test_delete_newsletter() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("author").await;
+
+    // Create a newsletter
+    let newsletter_data = json!({
+        "title": "To Be Deleted",
+        "subject": "Delete Test",
+        "body": "This newsletter will be deleted"
+    });
+
+    let create_response = app
+        .client
+        .post(format!("{}/api/admin/newsletters", &app.address))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&newsletter_data)
+        .send()
+        .await
+        .expect("Failed to create newsletter");
+
+    let create_body: Value = create_response.json().await.expect("Failed to parse response");
+    let newsletter_id = create_body["data"]["id"].as_str().unwrap();
+
+    // Act - Delete the newsletter
+    let delete_response = app
+        .client
+        .delete(format!("{}/api/admin/newsletters/{}", &app.address, newsletter_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to delete newsletter");
+
+    // Assert
+    assert_eq!(delete_response.status(), StatusCode::OK);
+
+    // Verify it's deleted
+    let get_response = app
+        .client
+        .get(format!("{}/api/admin/newsletters/{}", &app.address, newsletter_id))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to get newsletter");
+
+    assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
- Add send_newsletter_confirmation and send_newsletter_issue methods to EmailService
- Implement actual email sending in subscribe handler with confirmation emails
- Implement idempotent newsletter delivery (checks delivery_logs before sending)
- Add personalized content based on followed authors' recent articles
- Add responsive HTML email templates for both confirmation and newsletter emails
- Improve admin newsletter UI for mobile responsiveness (2x2 grid on mobile)
- Add 6 new comprehensive tests: idempotency, delivery logs, resubscribe flow, send with no subscribers, update newsletter, delete newsletter
- All 323 tests pass