### PR TITLE
fix: enable client-side theme switching and add integration tests

### DIFF
--- a/src/lib/models/user.rs
+++ b/src/lib/models/user.rs
@@ -173,7 +173,7 @@ pub struct AdminUsersQuery {
 // Theme preference models
 #[derive(Debug, Serialize)]
 pub struct ThemePreferenceResponse {
-    pub theme: String,
+    pub theme: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Validate)]

--- a/src/lib/routes/users.rs
+++ b/src/lib/routes/users.rs
@@ -568,7 +568,7 @@ pub async fn list_profiles(
 pub async fn get_theme_preference(
     State(state): State<AppState>,
     user: AuthenticatedUser,
-) -> Result<Json<ThemePreferenceResponse>, ApiError> {
+) -> Result<ApiResponse<ThemePreferenceResponse>, ApiError> {
     let conn = state
         .db
         .connect()
@@ -586,9 +586,9 @@ pub async fn get_theme_preference(
         .await?
         .ok_or_else(|| ApiError::NotFound("User not found".to_string()))?;
 
-    let theme: String = row.get::<String>(0).unwrap_or_else(|_| "auto".to_string());
+    let theme: Option<String> = row.get::<String>(0).ok();
 
-    Ok(Json(ThemePreferenceResponse { theme }))
+    Ok(ApiResponse::success(ThemePreferenceResponse { theme }))
 }
 
 /// Update user's theme preference
@@ -597,7 +597,7 @@ pub async fn update_theme_preference(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Json(payload): Json<ThemePreferenceUpdate>,
-) -> Result<Json<ThemePreferenceResponse>, ApiError> {
+) -> Result<ApiResponse<ThemePreferenceResponse>, ApiError> {
     payload
         .validate()
         .map_err(|e| ApiError::BadRequest(format!("Validation error: {}", e)))?;
@@ -631,8 +631,8 @@ pub async fn update_theme_preference(
     )
     .await?;
 
-    Ok(Json(ThemePreferenceResponse {
-        theme: payload.theme,
+    Ok(ApiResponse::success(ThemePreferenceResponse {
+        theme: Some(payload.theme),
     }))
 }
 
@@ -640,7 +640,7 @@ pub async fn update_theme_preference(
 /// GET /api/themes
 pub async fn list_themes(
     State(state): State<AppState>,
-) -> Result<Json<Vec<ThemeListItem>>, ApiError> {
+) -> Result<ApiResponse<Vec<ThemeListItem>>, ApiError> {
     let mut themes = state.available_themes();
 
     // Add 'auto' option
@@ -656,5 +656,5 @@ pub async fn list_themes(
         },
     );
 
-    Ok(Json(themes))
+    Ok(ApiResponse::success(themes))
 }

--- a/src/lib/state.rs
+++ b/src/lib/state.rs
@@ -173,6 +173,20 @@ fn load_templates(templates_dir: &str, config: &AppConfig) -> Result<&'static Te
             },
         );
 
+        // Register all_themes_css function to generate CSS for all themes
+        // This enables client-side theme switching without additional server requests
+        tera.register_function(
+            "all_themes_css",
+            |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+                let registry = THEME_REGISTRY.get();
+                let css = registry
+                    .map(|r| r.all_themes_css())
+                    .unwrap_or_default();
+
+                Ok(Value::String(css))
+            },
+        );
+
         Ok(tera)
     })
 }

--- a/src/lib/theme.rs
+++ b/src/lib/theme.rs
@@ -107,9 +107,14 @@ impl ThemeConfig {
         Ok(config)
     }
 
-    /// Generate CSS custom properties from theme colors
+    /// Generate CSS custom properties from theme colors (for :root)
     pub fn to_css(&self) -> String {
-        let mut css = String::from(":root {\n");
+        self.to_css_with_selector(":root")
+    }
+
+    /// Generate CSS custom properties with a specific selector
+    pub fn to_css_with_selector(&self, selector: &str) -> String {
+        let mut css = format!("{} {{\n", selector);
 
         // Add color variables
         for (key, value) in &self.theme.colors {
@@ -285,6 +290,21 @@ impl ThemeRegistry {
             })
             .collect()
     }
+
+    /// Generate CSS for all themes with data-theme attribute selectors
+    /// This allows client-side theme switching without server requests
+    pub fn all_themes_css(&self) -> String {
+        let mut css = String::new();
+
+        // Generate CSS for each theme with [data-theme="X"] selector
+        for config in self.themes.values() {
+            let selector = format!("[data-theme=\"{}\"]", config.theme.id);
+            css.push_str(&config.to_css_with_selector(&selector));
+            css.push('\n');
+        }
+
+        css
+    }
 }
 
 impl Default for ThemeRegistry {
@@ -412,5 +432,65 @@ preview_colors = ["#ff6b35", "#2c3e50", "#ffffff"]
             config.external_stylesheet(),
             Some("https://example.com/bootstrap.css")
         );
+    }
+
+    #[test]
+    fn test_to_css_with_selector() {
+        let toml_content = create_test_theme_toml();
+        let config: ThemeConfig = toml::from_str(&toml_content).unwrap();
+        let css = config.to_css_with_selector("[data-theme=\"test\"]");
+
+        assert!(css.contains("[data-theme=\"test\"] {"));
+        assert!(css.contains("--theme-primary:"));
+        assert!(!css.contains(":root"));
+    }
+
+    #[test]
+    fn test_all_themes_css() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Create two test themes
+        let theme1_dir = temp_dir.path().join("light");
+        fs::create_dir(&theme1_dir).unwrap();
+        fs::write(
+            theme1_dir.join("theme.toml"),
+            r##"
+[theme]
+id = "light"
+name = "Light"
+version = "1.0.0"
+[theme.supports]
+color_scheme = "light"
+[theme.colors]
+primary = "#ffffff"
+"##,
+        )
+        .unwrap();
+
+        let theme2_dir = temp_dir.path().join("dark");
+        fs::create_dir(&theme2_dir).unwrap();
+        fs::write(
+            theme2_dir.join("theme.toml"),
+            r##"
+[theme]
+id = "dark"
+name = "Dark"
+version = "1.0.0"
+[theme.supports]
+color_scheme = "dark"
+[theme.colors]
+primary = "#000000"
+"##,
+        )
+        .unwrap();
+
+        let registry = ThemeRegistry::load_from_directory(temp_dir.path()).unwrap();
+        let css = registry.all_themes_css();
+
+        // Should contain both themes with data-theme selectors
+        assert!(css.contains("[data-theme=\"light\"]"));
+        assert!(css.contains("[data-theme=\"dark\"]"));
+        assert!(css.contains("--theme-primary: #ffffff"));
+        assert!(css.contains("--theme-primary: #000000"));
     }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,9 +33,9 @@
             rel="stylesheet"
             href="{{ versioned_asset(path='/static/css/base.css') }}"
         />
-        <!-- Theme CSS variables from theme.toml -->
+        <!-- Theme CSS variables for all themes (enables client-side switching) -->
         <style id="theme-variables">
-{{ theme_css(theme=current_theme | default(value='default')) | safe }}
+{{ all_themes_css() | safe }}
         </style>
         <!-- Legacy override stylesheet (for backwards compatibility) -->
         <link

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -31,3 +31,4 @@ mod shortcodes;
 mod sitemap;
 mod tags;
 mod template_rendering;
+mod themes;

--- a/tests/api/themes.rs
+++ b/tests/api/themes.rs
@@ -1,0 +1,413 @@
+// tests/api/themes.rs
+//
+// Integration tests for the theming system
+
+use crate::helpers::{spawn_app, TestUserBuilder};
+use serde_json::json;
+
+// ============================================================================
+// Theme API Tests
+// ============================================================================
+
+#[tokio::test]
+async fn list_themes_returns_available_themes() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/api/themes", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to deserialize response");
+
+    // Should return success envelope
+    assert_eq!(body["success"], true);
+
+    // Should contain themes data
+    let themes = body["data"].as_array().expect("data should be an array");
+
+    // Should have at least the default themes
+    assert!(!themes.is_empty(), "Should have at least one theme");
+
+    // Each theme should have required fields
+    for theme in themes {
+        assert!(theme["id"].is_string(), "theme should have id");
+        assert!(theme["name"].is_string(), "theme should have name");
+        assert!(theme["color_scheme"].is_string(), "theme should have color_scheme");
+    }
+}
+
+#[tokio::test]
+async fn list_themes_contains_default_dark_and_high_contrast() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/api/themes", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to deserialize response");
+
+    let themes = body["data"].as_array().expect("data should be an array");
+    let theme_ids: Vec<&str> = themes
+        .iter()
+        .filter_map(|t| t["id"].as_str())
+        .collect();
+
+    assert!(theme_ids.contains(&"default"), "Should contain default theme");
+    assert!(theme_ids.contains(&"dark"), "Should contain dark theme");
+    assert!(theme_ids.contains(&"high-contrast"), "Should contain high-contrast theme");
+}
+
+#[tokio::test]
+async fn get_theme_preference_requires_authentication() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act - Try to get theme preference without authentication
+    let response = app
+        .client
+        .get(format!("{}/api/user/theme", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn get_theme_preference_returns_auto_for_new_user() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to deserialize response");
+
+    assert_eq!(body["success"], true);
+    // New users have 'auto' as default theme preference (follows system)
+    assert_eq!(
+        body["data"]["theme"], "auto",
+        "New user should have 'auto' theme preference"
+    );
+}
+
+#[tokio::test]
+async fn update_theme_preference_requires_authentication() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act - Try to update theme preference without authentication
+    let response = app
+        .client
+        .put(format!("{}/api/user/theme", &app.address))
+        .json(&json!({ "theme": "dark" }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 401);
+}
+
+#[tokio::test]
+async fn update_theme_preference_succeeds_with_valid_theme() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act - Update theme preference to dark
+    let response = app
+        .client
+        .put(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&json!({ "theme": "dark" }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to deserialize response");
+
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["theme"], "dark");
+}
+
+#[tokio::test]
+async fn update_theme_preference_persists_across_requests() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act - Update theme preference
+    app.client
+        .put(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&json!({ "theme": "high-contrast" }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Get theme preference
+    let response = app
+        .client
+        .get(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to deserialize response");
+
+    assert_eq!(body["data"]["theme"], "high-contrast");
+}
+
+#[tokio::test]
+async fn update_theme_preference_with_auto_succeeds() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act - Set theme to auto (follow system)
+    let response = app
+        .client
+        .put(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&json!({ "theme": "auto" }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .expect("Failed to deserialize response");
+
+    assert_eq!(body["data"]["theme"], "auto");
+}
+
+#[tokio::test]
+async fn update_theme_preference_with_invalid_theme_fails() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act - Try to set an invalid theme
+    let response = app
+        .client
+        .put(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&json!({ "theme": "nonexistent-theme" }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert - Should reject invalid themes
+    assert_eq!(response.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn update_theme_preference_with_empty_theme_fails() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act - Try to set empty theme
+    let response = app
+        .client
+        .put(format!("{}/api/user/theme", &app.address))
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&json!({ "theme": "" }))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 400);
+}
+
+// ============================================================================
+// Theme Template Rendering Tests
+// ============================================================================
+
+#[tokio::test]
+async fn homepage_includes_theme_css_variables() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body = response.text().await.expect("Failed to get response body");
+
+    // Should include theme variables style block
+    assert!(body.contains("id=\"theme-variables\""), "Should have theme-variables style block");
+
+    // Should include CSS variables for themes
+    assert!(body.contains("--theme-"), "Should include --theme- CSS variables");
+}
+
+#[tokio::test]
+async fn homepage_includes_data_theme_attribute() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body = response.text().await.expect("Failed to get response body");
+
+    // Should have data-theme attribute on html element
+    assert!(body.contains("data-theme="), "Should have data-theme attribute");
+}
+
+#[tokio::test]
+async fn homepage_includes_theme_switcher_script() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body = response.text().await.expect("Failed to get response body");
+
+    // Should include theme-switcher.js
+    assert!(body.contains("theme-switcher.js"), "Should include theme-switcher.js");
+}
+
+#[tokio::test]
+async fn account_settings_includes_theme_picker() {
+    // Arrange
+    let app = spawn_app().await;
+    let token = app.register_user_default("testuser").await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/account", &app.address))
+        .header("Cookie", format!("authToken={}", token))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body = response.text().await.expect("Failed to get response body");
+
+    // Should include theme picker section
+    assert!(body.contains("Theme Preferences"), "Should include theme preferences section");
+    assert!(body.contains("themePicker"), "Should include theme picker element");
+
+    // Should include theme options
+    assert!(body.contains("data-theme=\"auto\""), "Should include auto theme option");
+    assert!(body.contains("data-theme=\"default\""), "Should include light theme option");
+    assert!(body.contains("data-theme=\"dark\""), "Should include dark theme option");
+    assert!(body.contains("data-theme=\"high-contrast\""), "Should include high-contrast theme option");
+}
+
+#[tokio::test]
+async fn all_themes_css_includes_multiple_theme_selectors() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act
+    let response = app
+        .client
+        .get(format!("{}/", &app.address))
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Assert
+    assert_eq!(response.status().as_u16(), 200);
+
+    let body = response.text().await.expect("Failed to get response body");
+
+    // Should include CSS selectors for different themes
+    assert!(
+        body.contains("[data-theme=\"default\"]") || body.contains("[data-theme=\\\"default\\\"]"),
+        "Should include default theme CSS selector"
+    );
+    assert!(
+        body.contains("[data-theme=\"dark\"]") || body.contains("[data-theme=\\\"dark\\\"]"),
+        "Should include dark theme CSS selector"
+    );
+    assert!(
+        body.contains("[data-theme=\"high-contrast\"]") || body.contains("[data-theme=\\\"high-contrast\\\"]"),
+        "Should include high-contrast theme CSS selector"
+    );
+}


### PR DESCRIPTION
The theme switching was broken because CSS variables were only injected for the initial theme. Fix by generating CSS for all themes with proper [data-theme="X"] selectors:

- Add to_css_with_selector() method to ThemeConfig
- Add all_themes_css() method to ThemeRegistry
- Add all_themes_css() Tera function for template injection
- Update base.html to inject all themes' CSS at once
- Update theme API routes to use ApiResponse wrapper
- Make ThemePreferenceResponse.theme optional

Add 15 integration tests covering:
- Theme listing API (GET /api/themes)
- Theme preference get/update (GET/PUT /api/user/theme)
- Authentication requirements
- Valid/invalid theme validation
- Template rendering with theme CSS and data attributes
- Theme picker UI in account settings