### PR TITLE
chore: clean up legacy Bootstrap references after removal

### DIFF
--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -10,7 +10,9 @@ use shuttle_runtime::{CustomError, SecretStore};
 pub struct AppConfig {
     pub jwt_secret: String,
     pub templates_dir: String,
+    /// Deprecated: Bootstrap has been removed. Kept for backwards compatibility.
     pub external_stylesheet: String,
+    /// Deprecated: Bootstrap has been removed. Kept for backwards compatibility.
     pub override_stylesheet: String,
     pub app_version: String,
     pub allowed_origins: Vec<String>,
@@ -30,13 +32,14 @@ impl TryFrom<&SecretStore> for AppConfig {
             .get("TEMPLATES_DIR")
             .ok_or_else(|| anyhow!("Missing required templates directory: TEMPLATES_DIR"))?;
 
+        // Deprecated: Bootstrap has been removed. These now default to empty strings.
         let external_stylesheet = secrets
             .get("EXTERNAL_STYLESHEET")
-            .ok_or_else(|| anyhow!("Missing required configuration secret: EXTERNAL_STYLESHEET"))?;
+            .unwrap_or_default();
 
         let override_stylesheet = secrets
             .get("OVERRIDE_STYLESHEET")
-            .ok_or_else(|| anyhow!("Missing required configuration secret: OVERRIDE_STYLESHEET"))?;
+            .unwrap_or_default();
 
         // Get version from Cargo.toml at compile time
         let app_version = env!("CARGO_PKG_VERSION").to_string();

--- a/src/lib/state.rs
+++ b/src/lib/state.rs
@@ -67,27 +67,13 @@ fn load_templates(templates_dir: &str, config: &AppConfig) -> Result<&'static Te
     COMPILED_TEMPLATES.get_or_try_init(|| {
         let mut tera = Tera::new(templates_dir)?;
 
-        let external = config.external_stylesheet.clone();
-        let override_css = config.override_stylesheet.clone();
-
-        // Legacy theme_stylesheet function (for backwards compatibility)
+        // Deprecated: Bootstrap has been removed. This function now returns empty strings.
+        // Kept for backwards compatibility in case any templates still reference it.
         tera.register_function(
             "theme_stylesheet",
-            move |args: &HashMap<String, Value>| -> tera::Result<Value> {
-                use tera::from_value;
-
-                let which = args
-                    .get("which")
-                    .and_then(|v| from_value::<String>(v.clone()).ok())
-                    .unwrap_or_else(|| "external".to_string());
-
-                let url = match which.as_str() {
-                    "external" => &external,
-                    "override" => &override_css,
-                    _ => "",
-                };
-
-                Ok(Value::String(url.to_string()))
+            |_args: &HashMap<String, Value>| -> tera::Result<Value> {
+                // Bootstrap has been removed - return empty string
+                Ok(Value::String(String::new()))
             },
         );
 

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -103,7 +103,6 @@
                     This website uses the following third-party services:
                 </p>
                 <ul>
-                    <li><strong>Bootstrap CSS:</strong> For styling and layout (loaded from CDN)</li>
                     <li><strong>Font Awesome:</strong> For icons (loaded from CDN)</li>
                 </ul>
                 <p>

--- a/themes/dark/theme.toml
+++ b/themes/dark/theme.toml
@@ -49,10 +49,5 @@ body = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-ser
 heading = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
 monospace = "'Monaco', 'Menlo', 'Ubuntu Mono', monospace"
 
-[theme.external]
-stylesheets = [
-    "https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-]
-
 [theme.meta]
 preview_colors = ["#ff8f5a", "#0d1117", "#1a1a2e"]

--- a/themes/default/theme.toml
+++ b/themes/default/theme.toml
@@ -49,10 +49,5 @@ body = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-ser
 heading = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
 monospace = "'Monaco', 'Menlo', 'Ubuntu Mono', monospace"
 
-[theme.external]
-stylesheets = [
-    "https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-]
-
 [theme.meta]
 preview_colors = ["#ff6b35", "#2c3e50", "#667eea"]

--- a/themes/high-contrast/theme.toml
+++ b/themes/high-contrast/theme.toml
@@ -49,10 +49,5 @@ body = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-ser
 heading = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
 monospace = "'Monaco', 'Menlo', 'Ubuntu Mono', monospace"
 
-[theme.external]
-stylesheets = [
-    "https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-]
-
 [theme.meta]
 preview_colors = ["#0066cc", "#ffffff", "#000000"]


### PR DESCRIPTION
- Remove Bootstrap CDN URLs from all theme.toml files
- Deprecate external_stylesheet/override_stylesheet config (now optional with empty defaults)
- Update theme_stylesheet() Tera function to return empty strings
- Remove Bootstrap mention from privacy.html third-party services list
- All 68 tests still pass