### PR TITLE
perf: fix N+1 query problems in repository layer

### DIFF
--- a/src/lib/migrations/mod.rs
+++ b/src/lib/migrations/mod.rs
@@ -103,6 +103,12 @@ pub const MIGRATIONS: &[Migration] = &[
         up: include_str!("sql/013_add_article_columns.sql"),
         down: None,
     },
+    Migration {
+        version: 14,
+        name: "add_performance_indexes",
+        up: include_str!("sql/014_add_performance_indexes.sql"),
+        down: None, // Indexes don't need rollback
+    },
 ];
 
 /// Error type for migration operations.

--- a/src/lib/migrations/sql/014_add_performance_indexes.sql
+++ b/src/lib/migrations/sql/014_add_performance_indexes.sql
@@ -1,0 +1,14 @@
+-- Migration 014: Add performance indexes for optimized queries
+-- These indexes support the repository pattern optimizations
+
+-- Index for counting favorites per article (used in article listings)
+CREATE INDEX IF NOT EXISTS idx_user_favorites_article_id ON user_favorites (article_id);
+
+-- Index for checking if user favorited an article (composite for faster lookups)
+CREATE INDEX IF NOT EXISTS idx_user_favorites_article_user ON user_favorites (article_id, user_id);
+
+-- Index for feed queries - finding articles by followed users
+CREATE INDEX IF NOT EXISTS idx_user_follows_following_id ON user_follows (following_id);
+
+-- Composite index for common comment queries
+CREATE INDEX IF NOT EXISTS idx_comments_article_created ON comments (article_id, created_at ASC);

--- a/src/lib/repositories/article_libsql.rs
+++ b/src/lib/repositories/article_libsql.rs
@@ -212,17 +212,27 @@ impl ArticleRepository for LibSqlArticleRepository {
             .connect()
             .map_err(|e| RepositoryError::ConnectionError(e.to_string()))?;
 
+        let user_id_param = current_user_id
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+
+        // Optimized query that fetches all data in one round trip
         let mut rows = conn
             .query(
                 r"SELECT a.id, a.slug, a.title, a.description, a.body, a.author_id,
                          a.category_id, a.draft, a.created_at, a.updated_at, a.featured_image_id,
                          c.slug as category_slug,
-                         u.username, u.bio, u.image
+                         u.username, u.bio, u.image,
+                         (SELECT GROUP_CONCAT(t.name, ',') FROM article_tags at
+                          JOIN tags t ON at.tag_id = t.id WHERE at.article_id = a.id) as tags,
+                         (SELECT COUNT(*) FROM user_favorites WHERE article_id = a.id) as favorites_count,
+                         (SELECT 1 FROM user_favorites WHERE article_id = a.id AND user_id = ?) as is_favorited,
+                         (SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = a.author_id) as is_following
                   FROM articles a
                   LEFT JOIN categories c ON a.category_id = c.id
                   JOIN users u ON a.author_id = u.id
                   WHERE a.slug = ?",
-                libsql::params![slug],
+                libsql::params![user_id_param.clone(), user_id_param, slug],
             )
             .await?;
 
@@ -233,18 +243,20 @@ impl ArticleRepository for LibSqlArticleRepository {
             let bio: Option<String> = row.get(13).ok();
             let image: Option<String> = row.get(14).ok();
 
-            // Check if current user is following the author
-            let following = if let Some(user_id) = current_user_id {
-                let mut follow_rows = conn
-                    .query(
-                        "SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = ?",
-                        libsql::params![user_id.to_string(), article.author_id.to_string()],
-                    )
-                    .await?;
-                follow_rows.next().await?.is_some()
-            } else {
-                false
-            };
+            // Parse aggregated tags from GROUP_CONCAT result
+            let tags_str: Option<String> = row.get(15).ok();
+            let tag_list: Vec<String> = tags_str
+                .map(|s| s.split(',').map(|t| t.trim().to_string()).filter(|t| !t.is_empty()).collect())
+                .unwrap_or_default();
+
+            // Get favorites count from subquery result
+            let favorites_count: i32 = row.get(16).unwrap_or(0);
+
+            // Check if current user favorited (subquery returns 1 or NULL)
+            let favorited = current_user_id.is_some() && row.get::<i64>(17).unwrap_or(0) == 1;
+
+            // Check if current user follows author (subquery returns 1 or NULL)
+            let following = current_user_id.is_some() && row.get::<i64>(18).unwrap_or(0) == 1;
 
             let author = UserProfile {
                 username,
@@ -252,14 +264,6 @@ impl ArticleRepository for LibSqlArticleRepository {
                 image,
                 following,
             };
-
-            let tag_list = self.get_tags(article.id).await?;
-            let favorited = if let Some(user_id) = current_user_id {
-                self.is_favorited(article.id, user_id).await?
-            } else {
-                false
-            };
-            let favorites_count = self.favorites_count(article.id).await?;
 
             Ok(Some(ArticleWithDetails {
                 article,
@@ -324,11 +328,26 @@ impl ArticleRepository for LibSqlArticleRepository {
             format!("WHERE {}", where_clauses.join(" AND "))
         };
 
+        // Build optimized query that fetches all data in one round trip:
+        // - Article data with author and category
+        // - Aggregated tags using GROUP_CONCAT
+        // - Favorites count using subquery
+        // - User's favorited status (if logged in)
+        // - User's following status (if logged in)
+        let user_id_param = current_user_id
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+
         let query_str = format!(
             r"SELECT a.id, a.slug, a.title, a.description, a.body, a.author_id,
                      a.category_id, a.draft, a.created_at, a.updated_at, a.featured_image_id,
                      c.slug as category_slug,
-                     u.username, u.bio, u.image
+                     u.username, u.bio, u.image,
+                     (SELECT GROUP_CONCAT(t.name, ',') FROM article_tags at
+                      JOIN tags t ON at.tag_id = t.id WHERE at.article_id = a.id) as tags,
+                     (SELECT COUNT(*) FROM user_favorites WHERE article_id = a.id) as favorites_count,
+                     (SELECT 1 FROM user_favorites WHERE article_id = a.id AND user_id = ?) as is_favorited,
+                     (SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = a.author_id) as is_following
               FROM articles a
               LEFT JOIN categories c ON a.category_id = c.id
               JOIN users u ON a.author_id = u.id
@@ -338,6 +357,9 @@ impl ArticleRepository for LibSqlArticleRepository {
             where_clause
         );
 
+        // Add user_id params for the subqueries (twice: once for favorites, once for follows)
+        params.insert(0, libsql::Value::Text(user_id_param.clone()));
+        params.insert(1, libsql::Value::Text(user_id_param));
         params.push(libsql::Value::Integer(limit as i64));
         params.push(libsql::Value::Integer(offset as i64));
 
@@ -353,17 +375,20 @@ impl ArticleRepository for LibSqlArticleRepository {
             let bio: Option<String> = row.get(13).ok();
             let image: Option<String> = row.get(14).ok();
 
-            let following = if let Some(user_id) = current_user_id {
-                let mut follow_rows = conn
-                    .query(
-                        "SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = ?",
-                        libsql::params![user_id.to_string(), article.author_id.to_string()],
-                    )
-                    .await?;
-                follow_rows.next().await?.is_some()
-            } else {
-                false
-            };
+            // Parse aggregated tags from GROUP_CONCAT result
+            let tags_str: Option<String> = row.get(15).ok();
+            let tag_list: Vec<String> = tags_str
+                .map(|s| s.split(',').map(|t| t.trim().to_string()).filter(|t| !t.is_empty()).collect())
+                .unwrap_or_default();
+
+            // Get favorites count from subquery result
+            let favorites_count: i32 = row.get(16).unwrap_or(0);
+
+            // Check if current user favorited (subquery returns 1 or NULL)
+            let favorited = current_user_id.is_some() && row.get::<i64>(17).unwrap_or(0) == 1;
+
+            // Check if current user follows author (subquery returns 1 or NULL)
+            let following = current_user_id.is_some() && row.get::<i64>(18).unwrap_or(0) == 1;
 
             let author = UserProfile {
                 username,
@@ -371,14 +396,6 @@ impl ArticleRepository for LibSqlArticleRepository {
                 image,
                 following,
             };
-
-            let tag_list = self.get_tags(article.id).await?;
-            let favorited = if let Some(user_id) = current_user_id {
-                self.is_favorited(article.id, user_id).await?
-            } else {
-                false
-            };
-            let favorites_count = self.favorites_count(article.id).await?;
 
             articles.push(ArticleWithDetails {
                 article,
@@ -468,10 +485,15 @@ impl ArticleRepository for LibSqlArticleRepository {
         let limit = query.limit.unwrap_or(20);
         let offset = query.offset.unwrap_or(0);
 
+        // Optimized query that fetches all data in one round trip
         let query_str = r"SELECT a.id, a.slug, a.title, a.description, a.body, a.author_id,
                                  a.category_id, a.draft, a.created_at, a.updated_at, a.featured_image_id,
                                  c.slug as category_slug,
-                                 u.username, u.bio, u.image
+                                 u.username, u.bio, u.image,
+                                 (SELECT GROUP_CONCAT(t.name, ',') FROM article_tags at
+                                  JOIN tags t ON at.tag_id = t.id WHERE at.article_id = a.id) as tags,
+                                 (SELECT COUNT(*) FROM user_favorites WHERE article_id = a.id) as favorites_count,
+                                 (SELECT 1 FROM user_favorites WHERE article_id = a.id AND user_id = ?) as is_favorited
                           FROM articles a
                           LEFT JOIN categories c ON a.category_id = c.id
                           JOIN users u ON a.author_id = u.id
@@ -480,10 +502,11 @@ impl ArticleRepository for LibSqlArticleRepository {
                           ORDER BY a.created_at DESC
                           LIMIT ? OFFSET ?";
 
+        let user_id_str = user_id.to_string();
         let mut rows = conn
             .query(
                 query_str,
-                libsql::params![user_id.to_string(), limit, offset],
+                libsql::params![user_id_str.clone(), user_id_str, limit, offset],
             )
             .await?;
 
@@ -495,16 +518,24 @@ impl ArticleRepository for LibSqlArticleRepository {
             let bio: Option<String> = row.get(13).ok();
             let image: Option<String> = row.get(14).ok();
 
+            // Parse aggregated tags from GROUP_CONCAT result
+            let tags_str: Option<String> = row.get(15).ok();
+            let tag_list: Vec<String> = tags_str
+                .map(|s| s.split(',').map(|t| t.trim().to_string()).filter(|t| !t.is_empty()).collect())
+                .unwrap_or_default();
+
+            // Get favorites count from subquery result
+            let favorites_count: i32 = row.get(16).unwrap_or(0);
+
+            // Check if current user favorited (subquery returns 1 or NULL)
+            let favorited = row.get::<i64>(17).unwrap_or(0) == 1;
+
             let author = UserProfile {
                 username,
                 bio,
                 image,
                 following: true, // They're in the feed because we follow them
             };
-
-            let tag_list = self.get_tags(article.id).await?;
-            let favorited = self.is_favorited(article.id, user_id).await?;
-            let favorites_count = self.favorites_count(article.id).await?;
 
             articles.push(ArticleWithDetails {
                 article,
@@ -547,18 +578,24 @@ impl ArticleRepository for LibSqlArticleRepository {
             .connect()
             .map_err(|e| RepositoryError::ConnectionError(e.to_string()))?;
 
+        // Optimized query that fetches all data in one round trip
         let query_str = r"SELECT a.id, a.slug, a.title, a.description, a.body, a.author_id,
                                  a.category_id, a.draft, a.created_at, a.updated_at, a.featured_image_id,
                                  c.slug as category_slug,
-                                 u.username, u.bio, u.image
+                                 u.username, u.bio, u.image,
+                                 (SELECT GROUP_CONCAT(t.name, ',') FROM article_tags at
+                                  JOIN tags t ON at.tag_id = t.id WHERE at.article_id = a.id) as tags,
+                                 (SELECT COUNT(*) FROM user_favorites WHERE article_id = a.id) as favorites_count,
+                                 (SELECT 1 FROM user_favorites WHERE article_id = a.id AND user_id = ?) as is_favorited
                           FROM articles a
                           LEFT JOIN categories c ON a.category_id = c.id
                           JOIN users u ON a.author_id = u.id
                           WHERE a.draft = 1 AND a.author_id = ?
                           ORDER BY a.updated_at DESC";
 
+        let user_id_str = user_id.to_string();
         let mut rows = conn
-            .query(query_str, libsql::params![user_id.to_string()])
+            .query(query_str, libsql::params![user_id_str.clone(), user_id_str])
             .await?;
 
         let mut articles = Vec::new();
@@ -569,16 +606,24 @@ impl ArticleRepository for LibSqlArticleRepository {
             let bio: Option<String> = row.get(13).ok();
             let image: Option<String> = row.get(14).ok();
 
+            // Parse aggregated tags from GROUP_CONCAT result
+            let tags_str: Option<String> = row.get(15).ok();
+            let tag_list: Vec<String> = tags_str
+                .map(|s| s.split(',').map(|t| t.trim().to_string()).filter(|t| !t.is_empty()).collect())
+                .unwrap_or_default();
+
+            // Get favorites count from subquery result
+            let favorites_count: i32 = row.get(16).unwrap_or(0);
+
+            // Check if current user favorited (subquery returns 1 or NULL)
+            let favorited = row.get::<i64>(17).unwrap_or(0) == 1;
+
             let author = UserProfile {
                 username,
                 bio,
                 image,
-                following: false,
+                following: false, // User viewing their own drafts
             };
-
-            let tag_list = self.get_tags(article.id).await?;
-            let favorited = self.is_favorited(article.id, user_id).await?;
-            let favorites_count = self.favorites_count(article.id).await?;
 
             articles.push(ArticleWithDetails {
                 article,

--- a/src/lib/repositories/comment_libsql.rs
+++ b/src/lib/repositories/comment_libsql.rs
@@ -192,15 +192,21 @@ impl CommentRepository for LibSqlCommentRepository {
             .connect()
             .map_err(|e| RepositoryError::ConnectionError(e.to_string()))?;
 
+        let user_id_param = current_user_id
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+
+        // Optimized query that fetches following status in the same query
         let mut rows = conn
             .query(
                 r"SELECT c.id, c.body, c.author_id, c.article_id, c.created_at, c.updated_at,
-                         u.username, u.bio, u.image
+                         u.username, u.bio, u.image,
+                         (SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = c.author_id) as is_following
                   FROM comments c
                   JOIN users u ON c.author_id = u.id
                   WHERE c.article_id = ?
                   ORDER BY c.created_at ASC",
-                libsql::params![article_id.to_string()],
+                libsql::params![user_id_param, article_id.to_string()],
             )
             .await?;
 
@@ -224,18 +230,8 @@ impl CommentRepository for LibSqlCommentRepository {
             let bio: Option<String> = row.get(7).ok();
             let image: Option<String> = row.get(8).ok();
 
-            // Check following status
-            let following = if let Some(user_id) = current_user_id {
-                let mut follow_rows = conn
-                    .query(
-                        "SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = ?",
-                        libsql::params![user_id.to_string(), author_id.to_string()],
-                    )
-                    .await?;
-                follow_rows.next().await?.is_some()
-            } else {
-                false
-            };
+            // Check following status from subquery result
+            let following = current_user_id.is_some() && row.get::<i64>(9).unwrap_or(0) == 1;
 
             comments.push(CommentWithAuthor {
                 comment: CommentRecord {

--- a/src/lib/repositories/newsletter_libsql.rs
+++ b/src/lib/repositories/newsletter_libsql.rs
@@ -632,51 +632,32 @@ impl NewsletterRepository for LibSqlNewsletterRepository {
             .connect()
             .map_err(|e| RepositoryError::ConnectionError(e.to_string()))?;
 
-        let mut total_rows = conn
+        // Optimized: fetch all stats in a single query instead of 4 separate queries
+        let mut rows = conn
             .query(
-                "SELECT COUNT(*) FROM newsletter_subscribers WHERE unsubscribed_at IS NULL",
+                r"SELECT
+                    (SELECT COUNT(*) FROM newsletter_subscribers WHERE unsubscribed_at IS NULL) as total_subscribers,
+                    (SELECT COUNT(*) FROM newsletter_subscribers WHERE confirmed = 1 AND unsubscribed_at IS NULL) as confirmed_subscribers,
+                    (SELECT COUNT(*) FROM newsletter_issues) as total_issues,
+                    (SELECT COUNT(*) FROM newsletter_issues WHERE status = 'sent') as sent_issues",
                 (),
             )
             .await?;
-        let total_subscribers: i32 = if let Some(row) = total_rows.next().await? {
-            row.get(0).unwrap_or(0)
-        } else {
-            0
-        };
 
-        let mut confirmed_rows = conn.query("SELECT COUNT(*) FROM newsletter_subscribers WHERE confirmed = 1 AND unsubscribed_at IS NULL", ()).await?;
-        let confirmed_subscribers: i32 = if let Some(row) = confirmed_rows.next().await? {
-            row.get(0).unwrap_or(0)
+        if let Some(row) = rows.next().await? {
+            Ok(NewsletterStatsData {
+                total_subscribers: row.get(0).unwrap_or(0),
+                confirmed_subscribers: row.get(1).unwrap_or(0),
+                total_issues: row.get(2).unwrap_or(0),
+                sent_issues: row.get(3).unwrap_or(0),
+            })
         } else {
-            0
-        };
-
-        let mut issues_rows = conn
-            .query("SELECT COUNT(*) FROM newsletter_issues", ())
-            .await?;
-        let total_issues: i32 = if let Some(row) = issues_rows.next().await? {
-            row.get(0).unwrap_or(0)
-        } else {
-            0
-        };
-
-        let mut sent_rows = conn
-            .query(
-                "SELECT COUNT(*) FROM newsletter_issues WHERE status = 'sent'",
-                (),
-            )
-            .await?;
-        let sent_issues: i32 = if let Some(row) = sent_rows.next().await? {
-            row.get(0).unwrap_or(0)
-        } else {
-            0
-        };
-
-        Ok(NewsletterStatsData {
-            total_subscribers,
-            confirmed_subscribers,
-            total_issues,
-            sent_issues,
-        })
+            Ok(NewsletterStatsData {
+                total_subscribers: 0,
+                confirmed_subscribers: 0,
+                total_issues: 0,
+                sent_issues: 0,
+            })
+        }
     }
 }

--- a/src/lib/repositories/user_libsql.rs
+++ b/src/lib/repositories/user_libsql.rs
@@ -344,23 +344,30 @@ impl UserRepository for LibSqlUserRepository {
         let limit = query.limit.unwrap_or(20).min(100);
         let offset = query.offset.unwrap_or(0);
 
+        let user_id_param = current_user_id
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+
         // Only show users with Author or Admin role (not Subscribers)
         let mut where_clauses = vec![
-            "disabled = 0".to_string(),
-            "(role = 'author' OR role = 'admin')".to_string(),
+            "u.disabled = 0".to_string(),
+            "(u.role = 'author' OR u.role = 'admin')".to_string(),
         ];
         let mut params: Vec<libsql::Value> = Vec::new();
 
+        // First param is for the is_following subquery
+        params.push(libsql::Value::Text(user_id_param));
+
         // Exclude current user from results
         if let Some(current_id) = current_user_id {
-            where_clauses.push("id != ?".to_string());
+            where_clauses.push("u.id != ?".to_string());
             params.push(libsql::Value::Text(current_id.to_string()));
         }
 
         if let Some(search) = &query.search
             && !search.trim().is_empty()
         {
-            where_clauses.push("(username LIKE ? OR bio LIKE ?)".to_string());
+            where_clauses.push("(u.username LIKE ? OR u.bio LIKE ?)".to_string());
             let search_pattern = format!("%{}%", search.trim());
             params.push(libsql::Value::Text(search_pattern.clone()));
             params.push(libsql::Value::Text(search_pattern));
@@ -368,10 +375,13 @@ impl UserRepository for LibSqlUserRepository {
 
         let where_clause = where_clauses.join(" AND ");
 
+        // Optimized query that fetches following status in the same query
         let query_str = format!(
-            r"SELECT id, username, bio, image FROM users
+            r"SELECT u.id, u.username, u.bio, u.image,
+                     (SELECT 1 FROM user_follows WHERE follower_id = ? AND following_id = u.id) as is_following
+              FROM users u
               WHERE {}
-              ORDER BY username ASC
+              ORDER BY u.username ASC
               LIMIT ? OFFSET ?",
             where_clause
         );
@@ -385,20 +395,12 @@ impl UserRepository for LibSqlUserRepository {
 
         let mut profiles = Vec::new();
         while let Some(row) = rows.next().await? {
-            let user_id_str: String = row.get(0)?;
-            let user_id = Uuid::parse_str(&user_id_str)
-                .map_err(|e| RepositoryError::InternalError(format!("Invalid UUID: {}", e)))?;
-
             let username: String = row.get(1)?;
             let bio: Option<String> = row.get(2).ok();
             let image: Option<String> = row.get(3).ok();
 
-            // Check following status if current user is authenticated
-            let following = if let Some(current_id) = current_user_id {
-                self.is_following(current_id, user_id).await?
-            } else {
-                false
-            };
+            // Check following status from subquery result
+            let following = current_user_id.is_some() && row.get::<i64>(4).unwrap_or(0) == 1;
 
             profiles.push(UserProfile {
                 username,


### PR DESCRIPTION
Optimize critical database queries that were causing severe N+1 performance issues after the repository pattern refactor:

- Article list/feed/drafts: Consolidated 60-80 queries per page into single queries using subqueries for tags, favorites, and follow status
- Article get_with_details: Reduced from 5 queries to 1
- Comment list_for_article: Eliminated N+1 for follow status checks
- User list_profiles: Eliminated N+1 for follow status checks
- Newsletter get_stats: Consolidated 4 COUNT queries into 1

Added new database indexes for query optimization:
- user_favorites(article_id) for counting favorites
- user_favorites(article_id, user_id) composite index
- user_follows(following_id) for feed/reverse lookups
- comments(article_id, created_at) composite index